### PR TITLE
Misc fixes

### DIFF
--- a/kalbur/.gitignore
+++ b/kalbur/.gitignore
@@ -1,0 +1,2 @@
+*.swp
+vmlinux.h

--- a/kalbur/Makefile
+++ b/kalbur/Makefile
@@ -26,6 +26,7 @@ PRELIM_TARGETS = $(patsubst %.c,%.o, $(filter-out %.bpf.c, $(wildcard *.c)))
 PROC_MONITOR = proc_monitor
 LOADER = loader
 MESSAGE = message
+MESSAGE_LS = message_ls
 APPS = $(PROC_MONITOR)
 MESSAGE_CONSUMERS = consumer
 
@@ -105,6 +106,12 @@ $(SUPPORT):
 $(MESSAGE).o: $(MESSAGE).c
 	$(call msg,CC,$@)
 	$(Q)$(CC) -DAPPLY_ASSERT $(CFLAGS) $(DEBUG_FLAG) $(INCLUDES) -c $(filter %.c, $^) -o $@
+
+# Build user-space code
+$(MESSAGE_LS).o: $(MESSAGE_LS).c $(MESSAGE_LS).h
+	$(call msg,CC,$@)
+	$(Q)$(CC) -DAPPLY_ASSERT $(CFLAGS) $(DEBUG_FLAG) $(INCLUDES) -c $(filter %.c, $^) -o $@
+
 
 $(LOADER).o: $(LOADER).c $(PROC_MONITOR).skel.h
 	$(call msg,CC,$@)

--- a/kalbur/consumer.c
+++ b/kalbur/consumer.c
@@ -24,6 +24,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <symsearch.h>
+#include <message_ls.h>
 
 #define ASSIGN_WITH_SOFTWARE_BARRIER(lval, rval)                               \
 	do {                                                                   \

--- a/kalbur/consumer.c
+++ b/kalbur/consumer.c
@@ -559,6 +559,8 @@ static int prepare_thread_run(hashtable_t **ht, sqlite3 **database,
 	if (err) {
 		fprintf(stderr,
 			"prepare_thread_run: failed to create database connection in consumer\n");
+
+		delete_table(*ht);
 		goto error;
 	}
 
@@ -567,12 +569,17 @@ static int prepare_thread_run(hashtable_t **ht, sqlite3 **database,
 	if (err) {
 		fprintf(stderr,
 			"prepare_thread_run: failed to prepare sql statements in consumer\n");
+
+		delete_table(*ht);
+		sqlite3_close(*database);
 		goto error;
 	}
 
 	return CODE_SUCCESS;
 
 error:
+	*ht = NULL;
+	*database = NULL;
 	return CODE_FAILED;
 }
 
@@ -635,10 +642,5 @@ void *consumer(void *arg)
 	close_database(db);
 
 error:
-	if (hash_table)
-		free(hash_table);
-	if (db)
-		sqlite3_close(db);
-
 	return NULL;
 }

--- a/kalbur/message.c
+++ b/kalbur/message.c
@@ -238,6 +238,10 @@ static void link_message(struct msg_list *head, struct message_state *ms)
 		ms->next_msg = curr_first;
 		ms->prev_msg = (struct message_state *)head;
 		curr_first->prev_msg = ms;
+
+		// memory barrier needed here because head->first must be set
+		// after all other pointers have been set, as explained above.
+		__sync_synchronize();
 		head->first = ms;
 	}
 
@@ -402,6 +406,9 @@ static void unlink_message(struct msg_list *head, struct message_state *ms)
 	if (next != NULL)
 		next->prev_msg = prev;
 
+	// memory barrier needed here, to make sure ms is
+	// fully unlinked before its values are set to NULL.
+	__sync_synchronize();
 	ms->next_msg = NULL;
 	ms->prev_msg = NULL;
 

--- a/kalbur/message.c
+++ b/kalbur/message.c
@@ -406,9 +406,6 @@ static void unlink_message(struct msg_list *head, struct message_state *ms)
 	if (next != NULL)
 		next->prev_msg = prev;
 
-	// memory barrier needed here, to make sure ms is
-	// fully unlinked before its values are set to NULL.
-	__sync_synchronize();
 	ms->next_msg = NULL;
 	ms->prev_msg = NULL;
 

--- a/kalbur/message.c
+++ b/kalbur/message.c
@@ -4,8 +4,7 @@
  *
  * All incoming events from the kernel are placed in a generic struct, which is
  * then placed in a message list for consumption by worker threads.
- * This file provides all the code necessary for allocating, initializing, and
- * linking of these events.
+ * This file provides all the code necessary for allocating and initializing messages
  */
 
 #include <message_preds.h>
@@ -45,7 +44,7 @@ static void *allocate_message_data(void **copy_target, void *data, size_t size)
 
 /* Allocate message_state struct and set the appropriate complete predicate
  * based on the syscall number */
-static struct message_state *allocate_message_struct(int syscall, int cpu)
+struct message_state *allocate_message_struct(int syscall, int cpu)
 {
 	struct message_state *ms;
 	ms = calloc(1UL, sizeof(struct message_state));
@@ -215,45 +214,6 @@ error:
 	return CODE_FAILED;
 }
 
-/* Insert new message into the beginning of the message list */
-static void link_message(struct msg_list *head, struct message_state *ms)
-{
-	struct message_state *curr_first;
-
-	ASSERT(head != NULL, "link_message: head == NULL");
-	ASSERT(ms != NULL, "link_message: ms == NULL");
-
-	if (head->first == NULL) {
-		head->first = ms;
-		head->last = ms;
-
-		ms->next_msg = NULL;
-		ms->prev_msg = (struct message_state *)head;
-	} else {
-		curr_first = head->first;
-
-		/* Set the next and previous values of ms before linking into list
-                 * Threads only traverse next message, so to avoid leaving list in 
-                 * partial state we set the head->first, at the end. */
-		ms->next_msg = curr_first;
-		ms->prev_msg = (struct message_state *)head;
-		curr_first->prev_msg = ms;
-
-		// memory barrier needed here because head->first must be set
-		// after all other pointers have been set, as explained above.
-		__sync_synchronize();
-		head->first = ms;
-	}
-
-	head->elements += 1;
-}
-
-struct msg_list *initialize_msg_list(void)
-{
-	struct msg_list *head = calloc(1UL, sizeof(struct msg_list));
-	return head;
-}
-
 static inline int validate_event_header(struct probe_event_header *eh)
 {
 	if ((eh->event_time == 0))
@@ -281,11 +241,12 @@ int is_legal_event(struct probe_event_header *eh)
 error:
 	return 0;
 }
+
 /* get event header from one of the output events.
  * perf events buffer donot guarantee ordering, so 
  * it is legal for a message to have String data present,
  * before primary data */
-static struct probe_event_header *get_event_header(struct message_state *ms)
+struct probe_event_header *get_event_header(struct message_state *ms)
 {
 	void *p;
 	void *string;
@@ -319,97 +280,6 @@ out:
 		return NULL;
 
 	return eh;
-}
-
-struct message_state *get_message(struct msg_list *head,
-				  struct probe_event_header *eh_incoming,
-				  int cpu)
-{
-	struct message_state *ms;
-	struct probe_event_header *eh;
-	struct message_state *prev_gc;
-	ms = head->first;
-	prev_gc = NULL;
-
-	ASSERT(head != NULL, "get_message: head == NULL");
-	ASSERT(eh_incoming != NULL, "get_message: eh_incoming == NULL");
-
-	while (ms != NULL) {
-		eh = get_event_header(ms);
-		ASSERT(eh != NULL,
-		       "get_message: (eh = get_even_header(ms)) == NULL");
-		if (EVENT_HEADER_EQ(eh_incoming, eh)) {
-			if (!ms->complete) { // to check for repeated wakeups
-				ASSERT(ms->saved == 0,
-				       "get_message: ms->saved == 1");
-				ASSERT(ms->discard == 0,
-				       "get_message: ms->discard == 1");
-				return ms;
-			} else // If ms->complete and event headers are equal, then ignore
-				return NULL;
-		}
-
-		// Link saved messages together
-		// so freeing later is simpler
-		if (FREEABLE(ms)) {
-			if (prev_gc == NULL)
-				prev_gc = ms;
-			else {
-				prev_gc->next_gc = ms;
-				prev_gc = ms;
-			}
-		}
-
-		ms = ms->next_msg;
-	}
-
-	ASSERT(ms == NULL, "get_message: ms != NULL");
-	ms = allocate_message_struct(eh_incoming->syscall_nr, cpu);
-	if (ms != NULL)
-		link_message(head, ms);
-
-	return ms;
-}
-
-static void unlink_message(struct msg_list *head, struct message_state *ms)
-{
-	struct message_state *next;
-	struct message_state *prev;
-	int first = 0;
-
-	ASSERT(head != NULL, "unlink_message: head == NULL");
-	ASSERT(ms != NULL, "unlink_message: ms == NULL");
-
-	if (head->first == NULL)
-		return;
-
-	next = ms->next_msg;
-	prev = ms->prev_msg;
-
-	// prev should never be NULL it is
-	// either another message or the head
-	ASSERT(prev != NULL, "unlink_message: prev == NULL");
-
-	if ((void *)prev == (void *)head) {
-		head->first = next;
-		first = 1;
-	} else
-		prev->next_msg = next;
-
-	if (ms == head->last) {
-		if (first)
-			head->last = NULL;
-		else
-			head->last = prev;
-	}
-
-	if (next != NULL)
-		next->prev_msg = prev;
-
-	ms->next_msg = NULL;
-	ms->prev_msg = NULL;
-
-	head->elements -= 1;
 }
 
 static struct message_state *free_message(struct message_state *ms)
@@ -451,48 +321,8 @@ static struct message_state *free_message(struct message_state *ms)
 	return NULL;
 }
 
-void delete_message(struct msg_list *head, struct message_state **state)
+void delete_message(struct message_state **state)
 {
-	unlink_message(head, *state);
 	*state = free_message(*state);
 }
 
-/* Free all saved messages */
-void garbage_collect(struct msg_list *head, char *caller)
-{
-	struct message_state *ms;
-	struct message_state *tmp;
-
-	ms = head->first;
-	while (!TO_GC(ms))
-		ms = ms->next_msg;
-
-	if (ms == NULL)
-		return;
-
-	while (ms != NULL) {
-		tmp = ms->next_gc;
-		delete_message(head, &ms);
-
-		ms = tmp;
-	}
-}
-
-void *delete_message_list(struct msg_list *head)
-{
-	struct message_state *ms;
-	struct message_state *tmp;
-
-	ASSERT(head != NULL, "free_messages: head == NULL");
-
-	ms = head->first;
-	while (ms != NULL) {
-		tmp = ms->next_msg;
-		delete_message(head, &ms);
-		ms = tmp;
-	}
-
-	free(head);
-
-	return NULL;
-}

--- a/kalbur/message.h
+++ b/kalbur/message.h
@@ -111,22 +111,12 @@ struct message_state {
 	int discard;
 };
 
-struct msg_list {
-	struct message_state *first;
-	struct message_state *last;
-	int elements;
-};
-
 int construct_message_state(struct message_state *ms,
 			    struct probe_event_header *eh_local, void *data,
 			    unsigned int size);
-struct message_state *get_message(struct msg_list *head,
-				  struct probe_event_header *eh_incoming,
-				  int cpu);
-void delete_message(struct msg_list *head, struct message_state **ms);
-void garbage_collect(struct msg_list *head, char *caller);
-struct msg_list *initialize_msg_list(void);
-void *delete_message_list(struct msg_list *head);
 int is_legal_event(struct probe_event_header *eh);
+struct message_state *allocate_message_struct(int syscall, int cpu);
+struct probe_event_header *get_event_header(struct message_state *ms);
+void delete_message(struct message_state **ms);
 
 #endif // MESSAGE_H

--- a/kalbur/message_ls.c
+++ b/kalbur/message_ls.c
@@ -1,0 +1,181 @@
+#include <err.h>
+#include <stdlib.h>
+#include <message.h>
+#include "message_ls.h"
+
+struct msg_list *initialize_msg_list(void)
+{
+	struct msg_list *head = calloc(1UL, sizeof(struct msg_list));
+	return head;
+}
+
+static void unlink_message(struct msg_list *head, struct message_state *ms)
+{
+	struct message_state *next;
+	struct message_state *prev;
+	int first = 0;
+
+	ASSERT(head != NULL, "unlink_message: head == NULL");
+	ASSERT(ms != NULL, "unlink_message: ms == NULL");
+
+	if (head->first == NULL)
+		return;
+
+	next = ms->next_msg;
+	prev = ms->prev_msg;
+
+	// prev should never be NULL it is
+	// either another message or the head
+	ASSERT(prev != NULL, "unlink_message: prev == NULL");
+
+	if ((void *)prev == (void *)head) {
+		head->first = next;
+		first = 1;
+	} else
+		prev->next_msg = next;
+
+	if (ms == head->last) {
+		if (first)
+			head->last = NULL;
+		else
+			head->last = prev;
+	}
+
+	if (next != NULL)
+		next->prev_msg = prev;
+
+	ms->next_msg = NULL;
+	ms->prev_msg = NULL;
+
+	head->elements -= 1;
+}
+
+/* Insert new message into the beginning of the message list */
+static void link_message(struct msg_list *head, struct message_state *ms)
+{
+	struct message_state *curr_first;
+
+	ASSERT(head != NULL, "link_message: head == NULL");
+	ASSERT(ms != NULL, "link_message: ms == NULL");
+
+	if (head->first == NULL) {
+		head->first = ms;
+		head->last = ms;
+
+		ms->next_msg = NULL;
+		ms->prev_msg = (struct message_state *)head;
+	} else {
+		curr_first = head->first;
+
+		/* Set the next and previous values of ms before linking into list
+                 * Threads only traverse next message, so to avoid leaving list in 
+                 * partial state we set the head->first, at the end. */
+		ms->next_msg = curr_first;
+		ms->prev_msg = (struct message_state *)head;
+		curr_first->prev_msg = ms;
+
+		// memory barrier needed here because head->first must be set
+		// after all other pointers have been set, as explained above.
+		__sync_synchronize();
+		head->first = ms;
+	}
+
+	head->elements += 1;
+}
+
+void remove_message_from_list(struct msg_list *head,
+			      struct message_state **state)
+{
+	unlink_message(head, *state);
+	delete_message(state);
+}
+
+struct message_state *get_message(struct msg_list *head,
+				  struct probe_event_header *eh_incoming,
+				  int cpu)
+{
+	struct message_state *ms;
+	struct probe_event_header *eh;
+	struct message_state *prev_gc;
+	ms = head->first;
+	prev_gc = NULL;
+
+	ASSERT(head != NULL, "get_message: head == NULL");
+	ASSERT(eh_incoming != NULL, "get_message: eh_incoming == NULL");
+
+	while (ms != NULL) {
+		eh = get_event_header(ms);
+		ASSERT(eh != NULL,
+		       "get_message: (eh = get_even_header(ms)) == NULL");
+		if (EVENT_HEADER_EQ(eh_incoming, eh)) {
+			if (!ms->complete) { // to check for repeated wakeups
+				ASSERT(ms->saved == 0,
+				       "get_message: ms->saved == 1");
+				ASSERT(ms->discard == 0,
+				       "get_message: ms->discard == 1");
+				return ms;
+			} else // If ms->complete and event headers are equal, then ignore
+				return NULL;
+		}
+
+		// Link saved messages together
+		// so freeing later is simpler
+		if (FREEABLE(ms)) {
+			if (prev_gc == NULL)
+				prev_gc = ms;
+			else {
+				prev_gc->next_gc = ms;
+				prev_gc = ms;
+			}
+		}
+
+		ms = ms->next_msg;
+	}
+
+	ASSERT(ms == NULL, "get_message: ms != NULL");
+	ms = allocate_message_struct(eh_incoming->syscall_nr, cpu);
+	if (ms != NULL)
+		link_message(head, ms);
+
+	return ms;
+}
+
+/* Free all saved messages */
+void garbage_collect(struct msg_list *head, char *caller)
+{
+	struct message_state *ms;
+	struct message_state *tmp;
+
+	ms = head->first;
+	while (!TO_GC(ms))
+		ms = ms->next_msg;
+
+	if (ms == NULL)
+		return;
+
+	while (ms != NULL) {
+		tmp = ms->next_gc;
+		remove_message_from_list(head, &ms);
+
+		ms = tmp;
+	}
+}
+
+void *delete_message_list(struct msg_list *head)
+{
+	struct message_state *ms;
+	struct message_state *tmp;
+
+	ASSERT(head != NULL, "free_messages: head == NULL");
+
+	ms = head->first;
+	while (ms != NULL) {
+		tmp = ms->next_msg;
+		remove_message_from_list(head, &ms);
+		ms = tmp;
+	}
+
+	free(head);
+
+	return NULL;
+}

--- a/kalbur/message_ls.h
+++ b/kalbur/message_ls.h
@@ -1,0 +1,19 @@
+#ifndef MESSAGE_LS_H
+#define MESSAGE_LS_H
+
+struct msg_list *initialize_msg_list(void);
+void *delete_message_list(struct msg_list *head);
+struct message_state *get_message(struct msg_list *head,
+				  struct probe_event_header *eh_incoming,
+				  int cpu);
+void garbage_collect(struct msg_list *head, char *caller);
+void remove_message_from_list(struct msg_list *head,
+			      struct message_state **state);
+struct msg_list {
+	struct message_state *first;
+	struct message_state *last;
+	int elements;
+};
+
+#endif // MESSAGE_LS_H
+

--- a/kalbur/proc_monitor.bpf.c
+++ b/kalbur/proc_monitor.bpf.c
@@ -1424,6 +1424,18 @@ out:
 	return err;
 }
 
+/* We have two different functions for getting the inode number of struct socket:
+ * get_inode_from_socket_alloc() and get_inode_from_socket()
+ * get_inode_from_socket() takes the inode number of the socket from socket->file->f_inode.i_ino
+ * get_inode_from_socket_alloc() takes the inode from socket_alloc.vfs_inode->i_ino
+ * The reason for these two functions is because get_inode_from_socket_alloc() is used in the
+ * security_socket_post_create() hook. At this point the struct file* member of socket has not
+ * been created, so we cannot use that to get the inode number.
+ *
+ * get_inode_from_socket() is used in hooks where the struct file* member has been created.
+ * This member is created from the same inode object as socket_alloc.vfs_inode as can be seen
+ * in the following call chain: 
+ * __sys_socket -> sock_map_fd -> sock_alloc_file -> alloc_file_pseudo */
 __attribute__((always_inline)) static unsigned long
 get_inode_from_socket_alloc(struct socket *sock)
 {

--- a/kalbur/proc_monitor.c
+++ b/kalbur/proc_monitor.c
@@ -147,6 +147,12 @@ fail:
 	return CODE_FAILED;
 }
 
+static void mark_ms_as_garbage(struct message_state *ms)
+{
+	ASSERT(ms != NULL, "mark_ms_as_garbage: ms == NULL");
+	ms->saved = 1;
+}
+
 static void consume_kernel_events(void *ctx, int cpu, void *data,
 				  unsigned int size)
 {
@@ -205,7 +211,7 @@ out:
 	return;
 
 error:
-	delete_message(head, &ms);
+	mark_ms_as_garbage(ms);
 }
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)

--- a/kalbur/proc_monitor.c
+++ b/kalbur/proc_monitor.c
@@ -22,6 +22,7 @@
 #include <errno.h>
 #include <message.h>
 #include <loader.h>
+#include <message_ls.h>
 
 #define GARBAGE_COLLECT 5000
 #define GARBAGE_COLLECT_LIMIT (GARBAGE_COLLECT * 3)

--- a/kalbur/rule_engine/stmts.h
+++ b/kalbur/rule_engine/stmts.h
@@ -43,34 +43,34 @@ const char *CREATE_STMTS[] = {
 // #### SQL STATEMENTS ####
 // ########################
 
-char INSERT_EVENT[] = "INSERT INTO events(\
+unsigned char INSERT_EVENT[] = "INSERT INTO events(\
 				" EVENT_TIME "," TGID_PID "," SYSCALL "," COMM
-		      ") \
+			       ") \
 				VALUES(:" EVENT_TIME ",:" TGID_PID ",:" SYSCALL
-		      ",:" COMM ") RETURNING " EVENT_ID ";";
+			       ",:" COMM ") RETURNING " EVENT_ID ";";
 
-char INSERT_FILE_INFO[] = "INSERT INTO file_info(\
+unsigned char INSERT_FILE_INFO[] = "INSERT INTO file_info(\
 					" FILENAME "," INODE_NUMBER "," S_MAGIC
-			  ") \
+				   ") \
 					VALUES(:" FILENAME ",:" INODE_NUMBER
-			  ",:" S_MAGIC ")\
+				   ",:" S_MAGIC ")\
 					RETURNING " FILE_ID ";";
 
-char INSERT_PROC_MMAP[] = "INSERT INTO proc_mmap(\
+unsigned char INSERT_PROC_MMAP[] = "INSERT INTO proc_mmap(\
 					" EVENT_ID "," FILE_ID "," VM_BASE
-			  "," VM_FLAGS "," VM_PROT ", \
+				   "," VM_FLAGS "," VM_PROT ", \
 					" VM_LEN ") \
 					VALUES(:" EVENT_ID ",:" FILE_ID
-			  ",:" VM_BASE ",:" VM_FLAGS ",\
+				   ",:" VM_BASE ",:" VM_FLAGS ",\
 					:" VM_PROT ", :" VM_LEN ");";
 
-char INSERT_FORK_AND_FRIENDS_INFO[] = "INSERT INTO child_proc_info(\
+unsigned char INSERT_FORK_AND_FRIENDS_INFO[] = "INSERT INTO child_proc_info(\
 				       " EVENT_ID "," NEW_TGID_PID "," PPID
-				      "," CLONE_FLAGS ") VALUES\
+					       "," CLONE_FLAGS ") VALUES\
 					(:" EVENT_ID ",:" NEW_TGID_PID ",:" PPID
-				      ",:" CLONE_FLAGS ");";
+					       ",:" CLONE_FLAGS ");";
 
-char INSERT_PROCESS_INFO[] =
+unsigned char INSERT_PROCESS_INFO[] =
 	"INSERT INTO process_info(\
 					" EVENT_ID "," PPID "," FILE_ID "," ARGS
 	"," INTERPRETER "," UID "," GID "," EUID "," EGID "," STDIN_INODE
@@ -80,89 +80,91 @@ char INSERT_PROCESS_INFO[] =
 	",:" STDIN_TYPE ",:" STDOUT_INODE ",:" STDOUT_TYPE ",:" STDERR_INODE
 	",:" STDERR_TYPE ");";
 
-char INSERT_SOCKET_CREATE_INFO[] =
+unsigned char INSERT_SOCKET_CREATE_INFO[] =
 	"INSERT INTO socket_create_info(\
 				    " EVENT_ID "," INODE_NUMBER "," FAMILY
 	"," SOCK_TYPE ") VALUES(:" EVENT_ID ",:" INODE_NUMBER ",:" FAMILY
 	",:" SOCK_TYPE ");";
 
-char INSERT_TCP_CONN_INFO[] =
+unsigned char INSERT_TCP_CONN_INFO[] =
 	"INSERT INTO tcp_connection_info(\
 			       	" EVENT_ID "," TYPE "," SADDR "," SPORT
 	"," DADDR "," DPORT "," DIRECTION "," SOCK_INODE ") VALUES(:" EVENT_ID
 	",:" TYPE ",:" SADDR ",:" SPORT ",:" DADDR ",:" DPORT ",:" DIRECTION
 	",:" SOCK_INODE ");";
 
-char INSERT_LPE_INFO[] =
+unsigned char INSERT_LPE_INFO[] =
 	"INSERT INTO lpe(" EVENT_ID "," CALLER_RET_ADDR "," TARGET_FUNC
 	") VALUES (:" EVENT_ID ",:" CALLER_RET_ADDR ",:" TARGET_FUNC ");";
 
-char INSERT_PTRACE_INFO[] =
+unsigned char INSERT_PTRACE_INFO[] =
 	"INSERT INTO ptrace_event(" EVENT_ID "," REQUEST "," ADDR "," TARGET
 	") VALUES(:" EVENT_ID ",:" REQUEST ",:" ADDR ",:" TARGET ");";
 
-char INSERT_MODULE_INFO[] = "INSERT INTO module_load(" EVENT_ID "," FILE_ID
-			    ") VALUES(:" EVENT_ID ",:" FILE_ID ");";
+unsigned char INSERT_MODULE_INFO[] =
+	"INSERT INTO module_load(" EVENT_ID "," FILE_ID ") VALUES(:" EVENT_ID
+	",:" FILE_ID ");";
 
-char INSERT_MODPROBE_OVERWRITE_INFO[] =
+unsigned char INSERT_MODPROBE_OVERWRITE_INFO[] =
 	"INSERT INTO modprobe_overwrite_info(" EVENT_ID "," PATH_NAME
 	") VALUES(:" EVENT_ID ",:" PATH_NAME ");";
 
-char SELECT_FILE_ID[] = "SELECT * from file_info WHERE " INODE_NUMBER
-			" = :" INODE_NUMBER " and " S_MAGIC " = :" S_MAGIC ";";
+unsigned char SELECT_FILE_ID[] =
+	"SELECT * from file_info WHERE " INODE_NUMBER " = :" INODE_NUMBER
+	" and " S_MAGIC " = :" S_MAGIC ";";
 
-char SELECT_FILE_ID_PROC_INFO[] =
+unsigned char SELECT_FILE_ID_PROC_INFO[] =
 	"SELECT " FILE_ID " FROM process_info WHERE " EVENT_ID " = :" EVENT_ID
 	";";
 
-char SELECT_EVENT_SYSCALL_BY_ID[] =
+unsigned char SELECT_EVENT_SYSCALL_BY_ID[] =
 	"SELECT " SYSCALL " from events WHERE " EVENT_ID " = :" EVENT_ID ";";
 
-char SELECT_SMAGIC_BY_FILE_ID[] =
+unsigned char SELECT_SMAGIC_BY_FILE_ID[] =
 	"SELECT " S_MAGIC " from file_info WHERE " FILE_ID " = :" FILE_ID ";";
 
-char SELECT_SOCKET_BY_INODE[] =
+unsigned char SELECT_SOCKET_BY_INODE[] =
 	"SELECT " EVENT_ID " from socket_create_info WHERE " INODE_NUMBER
 	" = :" INODE_NUMBER ";";
 
-char SELECT_FILENAME_BY_FILE_ID[] =
+unsigned char SELECT_FILENAME_BY_FILE_ID[] =
 	"SELECT " FILENAME " from file_info WHERE " FILE_ID " = :" FILE_ID ";";
 
-char SELECT_STDOUT_BY_STDIN[] =
+unsigned char SELECT_STDOUT_BY_STDIN[] =
 	"SELECT " STDIN_INODE ", " EVENT_ID ", " FILE_ID
 	" from process_info WHERE " STDOUT_INODE " = :" STDOUT_INODE ";";
 
-char SELECT_STDIN_BY_STDOUT[] =
+unsigned char SELECT_STDIN_BY_STDOUT[] =
 	"SELECT " STDOUT_INODE ", " EVENT_ID
 	" from process_info WHERE " STDIN_INODE " = :" STDIN_INODE ";";
 
-char SELECT_TGID_BY_EVENT_ID[] =
+unsigned char SELECT_TGID_BY_EVENT_ID[] =
 	"SELECT " TGID_PID " from events WHERE " EVENT_ID " = :" EVENT_ID ";";
 
-char SELECT_IF_SOCK_CONN_EXISTS[] =
+unsigned char SELECT_IF_SOCK_CONN_EXISTS[] =
 	"SELECT " EVENT_ID " FROM events WHERE " TGID_PID " = :" TGID_PID
 	" and syscall = 41;";
 
-char SELECT_EVENT_IDS_BY_TGID[] =
+unsigned char SELECT_EVENT_IDS_BY_TGID[] =
 	"SELECT " EVENT_ID " FROM events where TGID_PID = :" TGID_PID
 	" and (syscall = 9 or syscall = 59);";
 
-char SELECT_VM_INFO_BY_EVENT_ID[] =
+unsigned char SELECT_VM_INFO_BY_EVENT_ID[] =
 	"SELECT " VM_BASE ", " VM_LEN ", " VM_PROT
 	" FROM proc_mmap WHERE " EVENT_ID " = :" EVENT_ID ";";
 
-char SELECT_COMM_BY_EVENT_ID[] =
+unsigned char SELECT_COMM_BY_EVENT_ID[] =
 	"SELECT " COMM " FROM events WHERE " EVENT_ID " = :" EVENT_ID ";";
 
-char SELECT_COMM[] =
+unsigned char SELECT_COMM[] =
 	"SELECT " COMM " FROM disallowed WHERE " COMM " = :" COMM ";";
 
-char BEGIN_STMT[] = "BEGIN;";
-char ROLLBACK_STMT[] = "ROLLBACK;";
-char COMMIT_STMT[] = "COMMIT;";
+unsigned char BEGIN_STMT[] = "BEGIN;";
+unsigned char ROLLBACK_STMT[] = "ROLLBACK;";
+unsigned char COMMIT_STMT[] = "COMMIT;";
 
 typedef struct stmt {
-	char *sql;
+	unsigned char *sql;
 	const size_t sql_len;
 } stmt_t;
 

--- a/kalbur/util/hash.c
+++ b/kalbur/util/hash.c
@@ -119,7 +119,7 @@ hashtable_t *init_hashtable(void)
 		      sizeof(struct entry *));
 }
 
-void *hash_get(hashtable_t *hash_table, char *key, size_t data_size)
+void *hash_get(hashtable_t *hash_table, unsigned char *key, size_t data_size)
 {
 	struct entry *e;
 	struct key_struct ks;
@@ -137,7 +137,8 @@ void *hash_get(hashtable_t *hash_table, char *key, size_t data_size)
 	return e->value;
 }
 
-int hash_put(hashtable_t *hash_table, char *key, void *value, size_t data_size)
+int hash_put(hashtable_t *hash_table, unsigned char *key, void *value,
+	     size_t data_size)
 {
 	struct entry *e;
 

--- a/kalbur/util/hash.c
+++ b/kalbur/util/hash.c
@@ -119,12 +119,12 @@ hashtable_t *init_hashtable(void)
 		      sizeof(struct entry *));
 }
 
-void *hash_get(hashtable_t *hash_table, unsigned char *key, size_t data_size)
+void *hash_get(hashtable_t *hash_table, unsigned char *key, size_t key_size)
 {
 	struct entry *e;
 	struct key_struct ks;
 
-	ks.key_hash = crc32c_hash(key, data_size);
+	ks.key_hash = crc32c_hash(key, key_size);
 	ks.key = key;
 
 	unsigned int index = key_index(ks.key_hash);
@@ -138,12 +138,12 @@ void *hash_get(hashtable_t *hash_table, unsigned char *key, size_t data_size)
 }
 
 int hash_put(hashtable_t *hash_table, unsigned char *key, void *value,
-	     size_t data_size)
+	     size_t key_size)
 {
 	struct entry *e;
 
 	struct key_struct ks;
-	ks.key_hash = crc32c_hash(key, data_size);
+	ks.key_hash = crc32c_hash(key, key_size);
 	ks.key = key;
 
 	unsigned int index = key_index(ks.key_hash);

--- a/kalbur/util/hash.h
+++ b/kalbur/util/hash.h
@@ -11,9 +11,9 @@
 #include "util.h"
 
 hashtable_t *init_hashtable(void);
-void *hash_get(hashtable_t *hash_table, unsigned char *key, size_t data_size);
+void *hash_get(hashtable_t *hash_table, unsigned char *key, size_t key_size);
 int hash_put(hashtable_t *hash_table, unsigned char *key, void *value,
-	     size_t data_size);
+	     size_t key_size);
 void hash_reset(hashtable_t *hash_table);
 void hash_dump(hashtable_t *hash_table);
 void delete_table(hashtable_t *hash_table);

--- a/kalbur/util/hash.h
+++ b/kalbur/util/hash.h
@@ -11,8 +11,9 @@
 #include "util.h"
 
 hashtable_t *init_hashtable(void);
-void *hash_get(hashtable_t *hash_table, char *key, size_t data_size);
-int hash_put(hashtable_t *hash_table, char *key, void *value, size_t data_size);
+void *hash_get(hashtable_t *hash_table, unsigned char *key, size_t data_size);
+int hash_put(hashtable_t *hash_table, unsigned char *key, void *value,
+	     size_t data_size);
 void hash_reset(hashtable_t *hash_table);
 void hash_dump(hashtable_t *hash_table);
 void delete_table(hashtable_t *hash_table);

--- a/kalbur/util/util.h
+++ b/kalbur/util/util.h
@@ -13,7 +13,7 @@
 
 struct key_struct {
 	uint32_t key_hash;
-	char *key;
+	unsigned char *key;
 };
 
 struct entry {


### PR DESCRIPTION
Bug fixes for message linking and unlinking. It was noted that while linking and unlinking a message from the message list, operation reordering could leave the list in an incorrect state momentarily. This is fixed by issuing a memory fence to force the order to remain as intended, as seen in the relevant [commit](https://github.com/trapmine/trapmine-linux-sensor/commit/6713a0c64e8ed5e56d059215e84f5164605fafc4). 

Contains some refactoring for consumer thread and hash table code.