### PR TITLE
Expose Process Context in Lua

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vscode/*
 cscope.*
 *.o
+*.a
 *.skel.h
 *.swp

--- a/kalbur/Makefile
+++ b/kalbur/Makefile
@@ -38,6 +38,7 @@ RULE_ENGINE = $(DATABASE_DIR)/database.o \
 			$(LUA_DIR)/lua_ptrace_info.o \
 			$(LUA_DIR)/lua_socket_create_info.o \
 			$(LUA_DIR)/lua_tcp_connection_info.o \
+			$(LUA_DIR)/lua_module_load_info.o \
 
 HELPERS = $(HASH) $(RULE_ENGINE) $(SYMSEARCH) $(HELPERS_FN) $(SAFE)
 SQLITE3 = $(INC_DIR)/sqlite3.o

--- a/kalbur/Makefile
+++ b/kalbur/Makefile
@@ -20,7 +20,21 @@ SAFE = $(UTIL_DIR)/safe_hash.o
 SYMSEARCH = $(UTIL_DIR)/symsearch.o
 HELPERS_FN = $(UTIL_DIR)/helpers.o
 
-RULE_ENGINE = $(DATABASE_DIR)/database.o $(DATABASE_DIR)/rules.o $(DATABASE_DIR)/notifier.o $(ENGINE_DIR)/engine.o $(ENGINE_DIR)/save_ms.o $(LUA_DIR)/lua_engine.o $(LUA_DIR)/lua_event.o $(LUA_DIR)/attr_handler.o $(LUA_DIR)/rule_manager.o $(LUA_DIR)/lua_ms_tags.o
+RULE_ENGINE = $(DATABASE_DIR)/database.o \
+			$(DATABASE_DIR)/rules.o \
+			$(DATABASE_DIR)/notifier.o \
+			$(ENGINE_DIR)/engine.o \
+			$(ENGINE_DIR)/save_ms.o \
+			$(LUA_DIR)/lua_engine.o \
+			$(LUA_DIR)/lua_event.o \
+			$(LUA_DIR)/lua_process.o \
+			$(LUA_DIR)/attr_handler.o \
+			$(LUA_DIR)/rule_manager.o \
+			$(LUA_DIR)/lua_ms_tags.o \
+			$(LUA_DIR)/lua_event_info.o \
+			$(LUA_DIR)/lua_file_info.o \
+			$(LUA_DIR)/lua_process_info.o \
+			$(LUA_DIR)/lua_mmap_info.o \
 
 HELPERS = $(HASH) $(RULE_ENGINE) $(SYMSEARCH) $(HELPERS_FN) $(SAFE)
 SQLITE3 = $(INC_DIR)/sqlite3.o
@@ -35,7 +49,7 @@ MESSAGE_LS = message_ls
 APPS = $(PROC_MONITOR)
 MESSAGE_CONSUMERS = consumer
 
-PROC_MONITOR_LINK_FLAGS = -lelf -lz -ldl -lpthread -lm 
+PROC_MONITOR_LINK_FLAGS = -lelf -lz -ldl -lpthread -lm -lbsd
 
 CLANG_BPF_SYS_INCLUDES = $(shell $(CLANG) -v -E - < /dev/null 2>&1 \
 			 | sed -n '/<...> search starts here:/,/End of search list./{ s| \(/.*\)|-idirafter \1|p }')

--- a/kalbur/Makefile
+++ b/kalbur/Makefile
@@ -40,6 +40,7 @@ RULE_ENGINE = $(DATABASE_DIR)/database.o \
 			$(LUA_DIR)/lua_tcp_connection_info.o \
 			$(LUA_DIR)/lua_module_load_info.o \
 			$(LUA_DIR)/lua_modprobe_overwrite_info.o \
+			$(LUA_DIR)/lua_process_lpe_info.o \
 
 HELPERS = $(HASH) $(RULE_ENGINE) $(SYMSEARCH) $(HELPERS_FN) $(SAFE)
 SQLITE3 = $(INC_DIR)/sqlite3.o

--- a/kalbur/Makefile
+++ b/kalbur/Makefile
@@ -37,6 +37,7 @@ RULE_ENGINE = $(DATABASE_DIR)/database.o \
 			$(LUA_DIR)/lua_mmap_info.o \
 			$(LUA_DIR)/lua_ptrace_info.o \
 			$(LUA_DIR)/lua_socket_create_info.o \
+			$(LUA_DIR)/lua_tcp_connection_info.o \
 
 HELPERS = $(HASH) $(RULE_ENGINE) $(SYMSEARCH) $(HELPERS_FN) $(SAFE)
 SQLITE3 = $(INC_DIR)/sqlite3.o

--- a/kalbur/Makefile
+++ b/kalbur/Makefile
@@ -39,6 +39,7 @@ RULE_ENGINE = $(DATABASE_DIR)/database.o \
 			$(LUA_DIR)/lua_socket_create_info.o \
 			$(LUA_DIR)/lua_tcp_connection_info.o \
 			$(LUA_DIR)/lua_module_load_info.o \
+			$(LUA_DIR)/lua_modprobe_overwrite_info.o \
 
 HELPERS = $(HASH) $(RULE_ENGINE) $(SYMSEARCH) $(HELPERS_FN) $(SAFE)
 SQLITE3 = $(INC_DIR)/sqlite3.o

--- a/kalbur/Makefile
+++ b/kalbur/Makefile
@@ -36,6 +36,7 @@ RULE_ENGINE = $(DATABASE_DIR)/database.o \
 			$(LUA_DIR)/lua_process_info.o \
 			$(LUA_DIR)/lua_mmap_info.o \
 			$(LUA_DIR)/lua_ptrace_info.o \
+			$(LUA_DIR)/lua_socket_create_info.o \
 
 HELPERS = $(HASH) $(RULE_ENGINE) $(SYMSEARCH) $(HELPERS_FN) $(SAFE)
 SQLITE3 = $(INC_DIR)/sqlite3.o

--- a/kalbur/Makefile
+++ b/kalbur/Makefile
@@ -35,6 +35,7 @@ RULE_ENGINE = $(DATABASE_DIR)/database.o \
 			$(LUA_DIR)/lua_file_info.o \
 			$(LUA_DIR)/lua_process_info.o \
 			$(LUA_DIR)/lua_mmap_info.o \
+			$(LUA_DIR)/lua_ptrace_info.o \
 
 HELPERS = $(HASH) $(RULE_ENGINE) $(SYMSEARCH) $(HELPERS_FN) $(SAFE)
 SQLITE3 = $(INC_DIR)/sqlite3.o

--- a/kalbur/rule_engine/database/database.c
+++ b/kalbur/rule_engine/database/database.c
@@ -281,6 +281,8 @@ int insert_event(sqlite3 *db, hashtable_t *ht, struct probe_event_header *eh)
 	sqlite3_stmt *ppStmt;
 	int err;
 	int event_id;
+	u64_t tgid;
+	u64_t pid;
 
 	ppStmt = hash_get(ht, INSERT_EVENT, sizeof(INSERT_EVENT));
 	if (ppStmt == NULL) {
@@ -289,8 +291,12 @@ int insert_event(sqlite3 *db, hashtable_t *ht, struct probe_event_header *eh)
 		return CODE_FAILED;
 	}
 
+	tgid = (eh->tgid_pid >> 32) & 0xFFFFFFFF;
+	pid = eh->tgid_pid & 0xFFFFFFFF;
+
 	SQLITE3_BIND_INT("insert_event", int64, EVENT_TIME, eh->event_time);
-	SQLITE3_BIND_INT("insert_event", int64, TGID_PID, eh->tgid_pid);
+	SQLITE3_BIND_INT("insert_event", int64, TGID, tgid);
+	SQLITE3_BIND_INT("insert_event", int64, PID, pid);
 	SQLITE3_BIND_INT("insert_event", int, SYSCALL, eh->syscall_nr);
 	SQLITE3_BIND_STR("insert_event", text, COMM, eh->comm);
 
@@ -475,7 +481,8 @@ int insert_proc_info(sqlite3 *db, hashtable_t *ht, struct message_state *ms,
 
 	SQLITE3_BIND_INT("insert_proc_info", int, EVENT_ID, event_id);
 	SQLITE3_BIND_INT("insert_proc_info", int, FILE_ID, file_id);
-	SQLITE3_BIND_INT("insert_proc_info", int64, PPID, pinfo->ppid);
+	SQLITE3_BIND_INT("insert_proc_info", int64, PARENT_TGID, (pinfo->ppid >> 32) & 0xFFFFFFFF);
+	SQLITE3_BIND_INT("insert_proc_info", int64, PARENT_PID, pinfo->ppid & 0xFFFFFFFF);
 	SQLITE3_BIND_INT("insert_proc_info", int, UID, pinfo->credentials.uid);
 	SQLITE3_BIND_INT("insert_proc_info", int, GID, pinfo->credentials.gid);
 	SQLITE3_BIND_INT("insert_proc_info", int, EUID,

--- a/kalbur/rule_engine/database/database.c
+++ b/kalbur/rule_engine/database/database.c
@@ -956,15 +956,15 @@ int select_all_process_info(sqlite3 *db, hashtable_t *ht,
 				(int)strlen((const char *)tmp_process_name) + 1;
 
 			if (tmp_args == NULL) {
-				tmp_args = (const unsigned char*) "";
+				tmp_args = (const unsigned char *)"";
 			}
 			tmp_args_len = (int)strlen((const char *)tmp_args) + 1;
 			if (tmp_env == NULL) {
-				tmp_env = (const unsigned char*) "";
+				tmp_env = (const unsigned char *)"";
 			}
 			tmp_env_len = (int)strlen((const char *)tmp_env) + 1;
 			if (tmp_interpreter == NULL) {
-				tmp_interpreter = (const unsigned char*) "";
+				tmp_interpreter = (const unsigned char *)"";
 			}
 			tmp_interpreter_len =
 				(int)strlen((const char *)tmp_interpreter) + 1;
@@ -1107,8 +1107,7 @@ int select_all_mmap_info(sqlite3 *db, hashtable_t *ht,
 		}
 		if (err == SQLITE_ROW) {
 			if (mmap_info_arr->size == mmap_info_arr->max_size) {
-				mmap_info_arr->max_size +=
-					PROCESS_INFO_CHUNK_SIZE;
+				mmap_info_arr->max_size += MMAP_INFO_CHUNK_SIZE;
 				tmp_values = realloc(
 					mmap_info_arr->values,
 					sizeof(struct process_info) *
@@ -1232,7 +1231,7 @@ int select_all_ptrace_info(sqlite3 *db, hashtable_t *ht,
 			if (ptrace_info_arr->size ==
 			    ptrace_info_arr->max_size) {
 				ptrace_info_arr->max_size +=
-					PROCESS_INFO_CHUNK_SIZE;
+					PTRACE_INFO_CHUNK_SIZE;
 				tmp_values =
 					realloc(ptrace_info_arr->values,
 						sizeof(struct process_info) *
@@ -1337,7 +1336,7 @@ int select_all_socket_create_info(
 			if (socket_create_info_arr->size ==
 			    socket_create_info_arr->max_size) {
 				socket_create_info_arr->max_size +=
-					PROCESS_INFO_CHUNK_SIZE;
+					SOCKET_CREATE_INFO_CHUNK_SIZE;
 				tmp_values = realloc(
 					socket_create_info_arr->values,
 					sizeof(struct process_info) *
@@ -1362,13 +1361,13 @@ int select_all_socket_create_info(
 			SQLITE3_GET(tmp_inode, int64, 3);
 			SQLITE3_GET(tmp_family, text, 4);
 			if (tmp_family == NULL) {
-				tmp_family = (const unsigned char*) "";
+				tmp_family = (const unsigned char *)"";
 			}
 			tmp_family_len =
 				(int)strlen((const char *)tmp_family) + 1;
 			SQLITE3_GET(tmp_sock_type, text, 5);
 			if (tmp_sock_type == NULL) {
-				tmp_sock_type = (const unsigned char*) "";
+				tmp_sock_type = (const unsigned char *)"";
 			}
 			tmp_sock_type_len =
 				(int)strlen((const char *)tmp_sock_type) + 1;
@@ -1480,7 +1479,7 @@ int select_all_tcp_connection_info(
 			if (tcp_connection_info_arr->size ==
 			    tcp_connection_info_arr->max_size) {
 				tcp_connection_info_arr->max_size +=
-					PROCESS_INFO_CHUNK_SIZE;
+					TCP_CONNECTION_INFO_CHUNK_SIZE;
 				tmp_values = realloc(
 					tcp_connection_info_arr->values,
 					sizeof(struct process_info) *
@@ -1504,17 +1503,19 @@ int select_all_tcp_connection_info(
 
 			SQLITE3_GET(tmp_inet_type, text, 3);
 			if (tmp_inet_type == NULL) {
-				tmp_inet_type = (const unsigned char*) "";
+				tmp_inet_type = (const unsigned char *)"";
 			}
 			tmp_inet_type_len =
 				(int)strlen((const char *)tmp_inet_type) + 1;
 
 			SQLITE3_GET(tmp_direction, text, 8);
 			SQLITE3_GET(tmp_inode, int, 9);
-			if (strcmp((const char*)tmp_direction, "outgoing") == 0) {
+			if (strcmp((const char *)tmp_direction, "outgoing") ==
+			    0) {
 				SQLITE3_GET(tmp_src_addr, text, 4);
 				if (tmp_src_addr == NULL) {
-					tmp_src_addr = (const unsigned char*) "";
+					tmp_src_addr =
+						(const unsigned char *)"";
 				}
 				tmp_src_addr_len =
 					(int)strlen(
@@ -1524,17 +1525,20 @@ int select_all_tcp_connection_info(
 
 				SQLITE3_GET(tmp_dst_addr, text, 6);
 				if (tmp_dst_addr == NULL) {
-					tmp_dst_addr = (const unsigned char*) "";
+					tmp_dst_addr =
+						(const unsigned char *)"";
 				}
 				tmp_dst_addr_len =
 					(int)strlen(
 						(const char *)tmp_dst_addr) +
 					1;
 				SQLITE3_GET(tmp_dst_port, int, 7);
-			} else if (strcmp((const char*)tmp_direction, "incoming") == 0) {
+			} else if (strcmp((const char *)tmp_direction,
+					  "incoming") == 0) {
 				SQLITE3_GET(tmp_src_addr, text, 6);
 				if (tmp_src_addr == NULL) {
-					tmp_src_addr = (const unsigned char*) "";
+					tmp_src_addr =
+						(const unsigned char *)"";
 				}
 				tmp_src_addr_len =
 					(int)strlen(
@@ -1544,7 +1548,8 @@ int select_all_tcp_connection_info(
 
 				SQLITE3_GET(tmp_dst_addr, text, 4);
 				if (tmp_dst_addr == NULL) {
-					tmp_dst_addr = (const unsigned char*) "";
+					tmp_dst_addr =
+						(const unsigned char *)"";
 				}
 				tmp_dst_addr_len =
 					(int)strlen(
@@ -1678,7 +1683,7 @@ int select_all_module_load_info(sqlite3 *db, hashtable_t *ht,
 			if (module_load_info_arr->size ==
 			    module_load_info_arr->max_size) {
 				module_load_info_arr->max_size +=
-					PROCESS_INFO_CHUNK_SIZE;
+					MODULE_LOAD_INFO_CHUNK_SIZE;
 				tmp_values = realloc(
 					module_load_info_arr->values,
 					sizeof(struct process_info) *
@@ -1749,6 +1754,132 @@ int select_all_module_load_info(sqlite3 *db, hashtable_t *ht,
 			module_load_info_arr
 				->values[module_load_info_arr->size - 1]
 				->file_info->s_magic = tmp_s_magic;
+		}
+	}
+
+	err = err == SQLITE_DONE ? CODE_SUCCESS : CODE_FAILED;
+
+	sqlite3_clear_bindings(ppStmt);
+	sqlite3_reset(ppStmt);
+
+	return err;
+}
+
+int select_all_modprobe_overwrite_info(
+	sqlite3 *db, hashtable_t *ht,
+	lua_modprobe_overwrite_info_array *modprobe_overwrite_info_arr,
+	int tgid)
+{
+	int err;
+	sqlite3_stmt *ppStmt;
+	u64_t tmp_event_time;
+	int tmp_syscall;
+	const unsigned char *tmp_process_name;
+	int tmp_process_name_len;
+	const unsigned char *tmp_new_modprobe_path;
+	int tmp_new_modprobe_path_len;
+	struct lua_modprobe_overwrite_info **tmp_values;
+
+	ASSERT(modprobe_overwrite_info_arr != NULL,
+	       "select_all_modprobe_overwrite_info: modprobe_overwrite_info_arr is NULL");
+	ASSERT(modprobe_overwrite_info_arr->values != NULL,
+	       "select_all_modprobe_overwrite_info: modprobe_overwrite_info_arr->values is NULL");
+	ASSERT(modprobe_overwrite_info_arr->size == 0,
+	       "select_all_modprobe_overwrite_info: modprobe_overwrite_info_arr is non-empty");
+
+	ppStmt = (sqlite3_stmt *)hash_get(
+		ht, SELECT_MODPROBE_OVERWRITE_INFO,
+		sizeof(SELECT_MODPROBE_OVERWRITE_INFO));
+	if (ppStmt == NULL) {
+		fprintf(stderr,
+			"select_all_modprobe_overwrite_info: Failed to acquire prepared statement from hashmap.\n");
+		return CODE_FAILED;
+	}
+
+	SQLITE3_BIND_INT("select_all_modprobe_overwrite_info", int, TGID, tgid);
+
+	while (true) {
+		err = sqlite3_step(ppStmt);
+		if (err != SQLITE_ROW) {
+			break;
+		}
+		if (err == SQLITE_ROW) {
+			if (modprobe_overwrite_info_arr->size ==
+			    modprobe_overwrite_info_arr->max_size) {
+				modprobe_overwrite_info_arr->max_size +=
+					MODPROBE_OVERWRITE_INFO_CHUNK_SIZE;
+				tmp_values = realloc(
+					modprobe_overwrite_info_arr->values,
+					sizeof(struct process_info) *
+						(size_t)modprobe_overwrite_info_arr
+							->max_size);
+				if (tmp_values == NULL) {
+					fprintf(stderr,
+						"select_all_modprobe_overwrite_info: Failed to realloc memory for modprobe_overwrite_info_arr->values\n");
+					sqlite3_clear_bindings(ppStmt);
+					sqlite3_reset(ppStmt);
+					return CODE_FAILED;
+				}
+				modprobe_overwrite_info_arr->values =
+					tmp_values;
+			}
+			modprobe_overwrite_info_arr->size += 1;
+			SQLITE3_GET(tmp_event_time, int64, 0);
+			SQLITE3_GET(tmp_syscall, int, 1);
+			SQLITE3_GET(tmp_process_name, text, 2);
+			tmp_process_name_len =
+				(int)strlen((const char *)tmp_process_name) + 1;
+
+			SQLITE3_GET(tmp_new_modprobe_path, text, 3);
+			if (tmp_new_modprobe_path == NULL) {
+				tmp_new_modprobe_path =
+					(const unsigned char *)"";
+			}
+			tmp_new_modprobe_path_len =
+				(int)strlen(
+					(const char *)tmp_new_modprobe_path) +
+				1;
+
+			modprobe_overwrite_info_arr
+				->values[modprobe_overwrite_info_arr->size -
+					 1] = (struct lua_modprobe_overwrite_info
+						       *)
+				malloc(sizeof(
+					struct lua_modprobe_overwrite_info));
+			modprobe_overwrite_info_arr
+				->values[modprobe_overwrite_info_arr->size - 1]
+				->event_info = (struct lua_event_info *)malloc(
+				sizeof(struct lua_event_info));
+			modprobe_overwrite_info_arr
+				->values[modprobe_overwrite_info_arr->size - 1]
+				->event_info->process_name = (char *)malloc(
+				(sizeof(char) * (size_t)tmp_process_name_len));
+			modprobe_overwrite_info_arr
+				->values[modprobe_overwrite_info_arr->size - 1]
+				->event_info->event_time = tmp_event_time;
+			modprobe_overwrite_info_arr
+				->values[modprobe_overwrite_info_arr->size - 1]
+				->event_info->syscall = tmp_syscall;
+			strlcpy(modprobe_overwrite_info_arr
+					->values[modprobe_overwrite_info_arr
+							 ->size -
+						 1]
+					->event_info->process_name,
+				(const char *)tmp_process_name,
+				(size_t)tmp_process_name_len);
+
+			modprobe_overwrite_info_arr
+				->values[modprobe_overwrite_info_arr->size - 1]
+				->new_modprobe_path = (char *)malloc(
+				(sizeof(char) *
+				 (size_t)tmp_new_modprobe_path_len));
+			strlcpy(modprobe_overwrite_info_arr
+					->values[modprobe_overwrite_info_arr
+							 ->size -
+						 1]
+					->new_modprobe_path,
+				(const char *)tmp_new_modprobe_path,
+				(size_t)tmp_new_modprobe_path_len);
 		}
 	}
 

--- a/kalbur/rule_engine/database/database.c
+++ b/kalbur/rule_engine/database/database.c
@@ -856,11 +856,32 @@ int select_all_process_info(sqlite3 *db, hashtable_t *ht,
 	int err;
 	sqlite3_stmt *ppStmt;
 	u64_t tmp_event_time;
-	u64_t tmp_ppid;
+	u64_t tmp_parent_tgid;
 	int tmp_syscall;
 	const unsigned char *tmp_process_name;
 	int tmp_process_name_len;
 	struct lua_process_info **tmp_values;
+	u64_t tmp_clone_flags;
+	const unsigned char *tmp_args;
+	int tmp_args_len;
+	const unsigned char *tmp_env;
+	int tmp_env_len;
+	const unsigned char *tmp_interpreter;
+	int tmp_interpreter_len;
+	int tmp_uid;
+	int tmp_gid;
+	int tmp_euid;
+	int tmp_egid;
+	int tmp_stdin_inode;
+	int tmp_stdin_type;
+	int tmp_stdout_inode;
+	int tmp_stdout_type;
+	int tmp_stderr_inode;
+	int tmp_stderr_type;
+	const unsigned char *tmp_filename;
+	int tmp_filename_len;
+	u64_t tmp_inode;
+	u64_t tmp_s_magic;
 
 	ASSERT(process_info_arr != NULL,
 	       "select_all_process_info: process_info_arr is NULL");
@@ -907,9 +928,42 @@ int select_all_process_info(sqlite3 *db, hashtable_t *ht,
 			SQLITE3_GET(tmp_event_time, int64, 0);
 			SQLITE3_GET(tmp_syscall, int, 1);
 			SQLITE3_GET(tmp_process_name, text, 2);
-			SQLITE3_GET(tmp_ppid, int64, 3);
+			SQLITE3_GET(tmp_parent_tgid, int64, 3);
+			SQLITE3_GET(tmp_clone_flags, int64, 4);
+			SQLITE3_GET(tmp_args, text, 5);
+			SQLITE3_GET(tmp_env, text, 6);
+			SQLITE3_GET(tmp_interpreter, text, 7);
+			SQLITE3_GET(tmp_uid, int, 8);
+			SQLITE3_GET(tmp_gid, int, 9);
+			SQLITE3_GET(tmp_euid, int, 10);
+			SQLITE3_GET(tmp_egid, int, 11);
+			SQLITE3_GET(tmp_stdin_inode, int, 12);
+			SQLITE3_GET(tmp_stdin_type, int, 13);
+			SQLITE3_GET(tmp_stdout_inode, int, 14);
+			SQLITE3_GET(tmp_stdout_type, int, 15);
+			SQLITE3_GET(tmp_stderr_inode, int, 16);
+			SQLITE3_GET(tmp_stderr_type, int, 17);
+			SQLITE3_GET(tmp_filename, text, 18);
+			SQLITE3_GET(tmp_inode, int64, 19);
+			SQLITE3_GET(tmp_s_magic, int64, 20);
 			tmp_process_name_len =
 				(int)strlen((const char *)tmp_process_name) + 1;
+
+			if (tmp_args == NULL) {
+				tmp_args = "";
+			}
+			tmp_args_len = (int)strlen((const char *)tmp_args) + 1;
+			if (tmp_env == NULL) {
+				tmp_env = "";
+			}
+			tmp_env_len = (int)strlen((const char *)tmp_env) + 1;
+			if (tmp_interpreter == NULL) {
+				tmp_interpreter = "";
+			}
+			tmp_interpreter_len =
+				(int)strlen((const char *)tmp_interpreter) + 1;
+			tmp_filename_len =
+				(int)strlen((const char *)tmp_filename) + 1;
 
 			process_info_arr->values[process_info_arr->size - 1] =
 				(struct lua_process_info *)malloc(
@@ -920,17 +974,79 @@ int select_all_process_info(sqlite3 *db, hashtable_t *ht,
 			process_info_arr->values[process_info_arr->size - 1]
 				->event_info->process_name = (char *)malloc(
 				(sizeof(char) * (size_t)tmp_process_name_len));
-			process_info_arr->values[process_info_arr->size - 1]
-				->event_info->event_time = tmp_event_time;
-			process_info_arr->values[process_info_arr->size - 1]
-				->event_info->syscall = tmp_syscall;
-			process_info_arr->values[process_info_arr->size - 1]
-				->ppid = tmp_ppid;
 			strlcpy(process_info_arr
 					->values[process_info_arr->size - 1]
 					->event_info->process_name,
 				(const char *)tmp_process_name,
 				(size_t)tmp_process_name_len);
+			process_info_arr->values[process_info_arr->size - 1]
+				->event_info->event_time = tmp_event_time;
+			process_info_arr->values[process_info_arr->size - 1]
+				->event_info->syscall = tmp_syscall;
+
+			process_info_arr->values[process_info_arr->size - 1]
+				->parent_tgid = tmp_parent_tgid;
+			process_info_arr->values[process_info_arr->size - 1]
+				->args = (char *)malloc(
+				(sizeof(char) * (size_t)tmp_args_len));
+			strlcpy(process_info_arr
+					->values[process_info_arr->size - 1]
+					->args,
+				(const char *)tmp_args, (size_t)tmp_args_len);
+			process_info_arr->values[process_info_arr->size - 1]
+				->env = (char *)malloc(
+				(sizeof(char) * (size_t)tmp_env_len));
+			strlcpy(process_info_arr
+					->values[process_info_arr->size - 1]
+					->env,
+				(const char *)tmp_env, (size_t)tmp_env_len);
+			process_info_arr->values[process_info_arr->size - 1]
+				->interpreter = (char *)malloc(
+				(sizeof(char) * (size_t)tmp_interpreter_len));
+			strlcpy(process_info_arr
+					->values[process_info_arr->size - 1]
+					->interpreter,
+				(const char *)tmp_interpreter,
+				(size_t)tmp_interpreter_len);
+
+			process_info_arr->values[process_info_arr->size - 1]
+				->clone_flags = tmp_clone_flags;
+			process_info_arr->values[process_info_arr->size - 1]
+				->uid = tmp_uid;
+			process_info_arr->values[process_info_arr->size - 1]
+				->gid = tmp_gid;
+			process_info_arr->values[process_info_arr->size - 1]
+				->euid = tmp_euid;
+			process_info_arr->values[process_info_arr->size - 1]
+				->egid = tmp_egid;
+			process_info_arr->values[process_info_arr->size - 1]
+				->stdin_inode = tmp_stdin_inode;
+			process_info_arr->values[process_info_arr->size - 1]
+				->stdout_inode = tmp_stdout_inode;
+			process_info_arr->values[process_info_arr->size - 1]
+				->stderr_inode = tmp_stderr_inode;
+			process_info_arr->values[process_info_arr->size - 1]
+				->stdin_type = tmp_stdin_type;
+			process_info_arr->values[process_info_arr->size - 1]
+				->stdout_type = tmp_stdout_type;
+			process_info_arr->values[process_info_arr->size - 1]
+				->stderr_type = tmp_stderr_type;
+
+			process_info_arr->values[process_info_arr->size - 1]
+				->file_info = (struct lua_file_info *)malloc(
+				sizeof(struct lua_file_info));
+			process_info_arr->values[process_info_arr->size - 1]
+				->file_info->filename = (char *)malloc(
+				(sizeof(char) * (size_t)tmp_filename_len));
+			strlcpy(process_info_arr
+					->values[process_info_arr->size - 1]
+					->file_info->filename,
+				(const char *)tmp_filename,
+				(size_t)tmp_filename_len);
+			process_info_arr->values[process_info_arr->size - 1]
+				->file_info->inode = tmp_inode;
+			process_info_arr->values[process_info_arr->size - 1]
+				->file_info->s_magic = tmp_s_magic;
 		}
 	}
 

--- a/kalbur/rule_engine/database/database.c
+++ b/kalbur/rule_engine/database/database.c
@@ -481,8 +481,10 @@ int insert_proc_info(sqlite3 *db, hashtable_t *ht, struct message_state *ms,
 
 	SQLITE3_BIND_INT("insert_proc_info", int, EVENT_ID, event_id);
 	SQLITE3_BIND_INT("insert_proc_info", int, FILE_ID, file_id);
-	SQLITE3_BIND_INT("insert_proc_info", int64, PARENT_TGID, (pinfo->ppid >> 32) & 0xFFFFFFFF);
-	SQLITE3_BIND_INT("insert_proc_info", int64, PARENT_PID, pinfo->ppid & 0xFFFFFFFF);
+	SQLITE3_BIND_INT("insert_proc_info", int64, PARENT_TGID,
+			 (pinfo->ppid >> 32) & 0xFFFFFFFF);
+	SQLITE3_BIND_INT("insert_proc_info", int64, PARENT_PID,
+			 pinfo->ppid & 0xFFFFFFFF);
 	SQLITE3_BIND_INT("insert_proc_info", int, UID, pinfo->credentials.uid);
 	SQLITE3_BIND_INT("insert_proc_info", int, GID, pinfo->credentials.gid);
 	SQLITE3_BIND_INT("insert_proc_info", int, EUID,
@@ -947,6 +949,9 @@ int select_all_mmap_info(sqlite3 *db, hashtable_t *ht,
 	sqlite3_stmt *ppStmt;
 	u64_t tmp_event_time;
 	u64_t tmp_vm_base;
+	u64_t tmp_vm_flags;
+	u64_t tmp_vm_prot;
+	u64_t tmp_vm_len;
 	int tmp_syscall;
 	const unsigned char *tmp_process_name;
 	int tmp_process_name_len;
@@ -1003,6 +1008,9 @@ int select_all_mmap_info(sqlite3 *db, hashtable_t *ht,
 				(int)strlen((const char *)tmp_process_name) + 1;
 
 			SQLITE3_GET(tmp_vm_base, int64, 3);
+			SQLITE3_GET(tmp_vm_flags, int64, 4);
+			SQLITE3_GET(tmp_vm_prot, int64, 5);
+			SQLITE3_GET(tmp_vm_len, int64, 6);
 
 			SQLITE3_GET(tmp_filename, text, 7);
 			// tmp_filename = sqlite3_column_text(ppStmt, 10);
@@ -1031,6 +1039,12 @@ int select_all_mmap_info(sqlite3 *db, hashtable_t *ht,
 
 			mmap_info_arr->values[mmap_info_arr->size - 1]->vm_base =
 				tmp_vm_base;
+			mmap_info_arr->values[mmap_info_arr->size - 1]
+				->vm_flags = tmp_vm_flags;
+			mmap_info_arr->values[mmap_info_arr->size - 1]->vm_prot =
+				tmp_vm_prot;
+			mmap_info_arr->values[mmap_info_arr->size - 1]->vm_len =
+				tmp_vm_len;
 
 			mmap_info_arr->values[mmap_info_arr->size - 1]
 				->file_info = (struct lua_file_info *)malloc(

--- a/kalbur/rule_engine/database/database.h
+++ b/kalbur/rule_engine/database/database.h
@@ -21,6 +21,7 @@ typedef struct lua_process_info_array lua_process_info_array;
 typedef struct lua_mmap_info_array lua_mmap_info_array;
 typedef struct lua_ptrace_info_array lua_ptrace_info_array;
 typedef struct lua_socket_create_info_array lua_socket_create_info_array;
+typedef struct lua_tcp_connection_info_array lua_tcp_connection_info_array;
 
 int create_connection(char *dbname, sqlite3 **db, int inmem);
 int initialize_database(char *dbname);
@@ -59,4 +60,7 @@ int select_all_ptrace_info(sqlite3 *db, hashtable_t *ht,
 int select_all_socket_create_info(sqlite3 *db, hashtable_t *ht,
 				  lua_socket_create_info_array *ptrace_info_arr,
 				  int tgid);
+int select_all_tcp_connection_info(
+	sqlite3 *db, hashtable_t *ht,
+	lua_tcp_connection_info_array *ptrace_info_arr, int tgid);
 #endif // DATABASE_H

--- a/kalbur/rule_engine/database/database.h
+++ b/kalbur/rule_engine/database/database.h
@@ -20,6 +20,7 @@
 typedef struct lua_process_info_array lua_process_info_array;
 typedef struct lua_mmap_info_array lua_mmap_info_array;
 typedef struct lua_ptrace_info_array lua_ptrace_info_array;
+typedef struct lua_socket_create_info_array lua_socket_create_info_array;
 
 int create_connection(char *dbname, sqlite3 **db, int inmem);
 int initialize_database(char *dbname);
@@ -55,4 +56,7 @@ int select_all_mmap_info(sqlite3 *db, hashtable_t *ht,
 			 lua_mmap_info_array *mmap_info_arr, int tgid);
 int select_all_ptrace_info(sqlite3 *db, hashtable_t *ht,
 			   lua_ptrace_info_array *ptrace_info_arr, int tgid);
+int select_all_socket_create_info(sqlite3 *db, hashtable_t *ht,
+				  lua_socket_create_info_array *ptrace_info_arr,
+				  int tgid);
 #endif // DATABASE_H

--- a/kalbur/rule_engine/database/database.h
+++ b/kalbur/rule_engine/database/database.h
@@ -19,6 +19,7 @@
 
 typedef struct lua_process_info_array lua_process_info_array;
 typedef struct lua_mmap_info_array lua_mmap_info_array;
+typedef struct lua_ptrace_info_array lua_ptrace_info_array;
 
 int create_connection(char *dbname, sqlite3 **db, int inmem);
 int initialize_database(char *dbname);
@@ -49,8 +50,9 @@ int commit_transaction(sqlite3 *db, hashtable_t *ht);
 int begin_transaction(sqlite3 *db, hashtable_t *ht);
 void close_database(sqlite3 *db);
 int select_all_process_info(sqlite3 *db, hashtable_t *ht,
-			    lua_process_info_array *process_info_arr,
-			    int tgid);
+			    lua_process_info_array *process_info_arr, int tgid);
 int select_all_mmap_info(sqlite3 *db, hashtable_t *ht,
 			 lua_mmap_info_array *mmap_info_arr, int tgid);
+int select_all_ptrace_info(sqlite3 *db, hashtable_t *ht,
+			   lua_ptrace_info_array *ptrace_info_arr, int tgid);
 #endif // DATABASE_H

--- a/kalbur/rule_engine/database/database.h
+++ b/kalbur/rule_engine/database/database.h
@@ -8,12 +8,17 @@
 #ifndef DATABASE_H
 #define DATABASE_H
 
+#include <bsd/string.h>
 #include <sqlite3.h>
 #include <events.h>
 #include <message.h>
 #include "util.h"
+#include "lua_process.h"
 
 #define TIMEOUT_MS 1000
+
+typedef struct lua_process_info_array lua_process_info_array;
+typedef struct lua_mmap_info_array lua_mmap_info_array;
 
 int create_connection(char *dbname, sqlite3 **db, int inmem);
 int initialize_database(char *dbname);
@@ -43,4 +48,9 @@ int rollback_transaction(sqlite3 *db, hashtable_t *ht);
 int commit_transaction(sqlite3 *db, hashtable_t *ht);
 int begin_transaction(sqlite3 *db, hashtable_t *ht);
 void close_database(sqlite3 *db);
+int select_all_process_info(sqlite3 *db, hashtable_t *ht,
+			    lua_process_info_array *process_info_arr,
+			    int tgid);
+int select_all_mmap_info(sqlite3 *db, hashtable_t *ht,
+			 lua_mmap_info_array *mmap_info_arr, int tgid);
 #endif // DATABASE_H

--- a/kalbur/rule_engine/database/database.h
+++ b/kalbur/rule_engine/database/database.h
@@ -22,6 +22,7 @@ typedef struct lua_mmap_info_array lua_mmap_info_array;
 typedef struct lua_ptrace_info_array lua_ptrace_info_array;
 typedef struct lua_socket_create_info_array lua_socket_create_info_array;
 typedef struct lua_tcp_connection_info_array lua_tcp_connection_info_array;
+typedef struct lua_module_load_info_array lua_module_load_info_array;
 
 int create_connection(char *dbname, sqlite3 **db, int inmem);
 int initialize_database(char *dbname);
@@ -63,4 +64,7 @@ int select_all_socket_create_info(sqlite3 *db, hashtable_t *ht,
 int select_all_tcp_connection_info(
 	sqlite3 *db, hashtable_t *ht,
 	lua_tcp_connection_info_array *ptrace_info_arr, int tgid);
+int select_all_module_load_info(sqlite3 *db, hashtable_t *ht,
+				lua_module_load_info_array *module_load_info_arr,
+				int tgid);
 #endif // DATABASE_H

--- a/kalbur/rule_engine/database/database.h
+++ b/kalbur/rule_engine/database/database.h
@@ -25,6 +25,7 @@ typedef struct lua_tcp_connection_info_array lua_tcp_connection_info_array;
 typedef struct lua_module_load_info_array lua_module_load_info_array;
 typedef struct lua_modprobe_overwrite_info_array
 	lua_modprobe_overwrite_info_array;
+typedef struct lua_process_lpe_info_array lua_process_lpe_info_array;
 
 int create_connection(char *dbname, sqlite3 **db, int inmem);
 int initialize_database(char *dbname);
@@ -73,4 +74,7 @@ int select_all_modprobe_overwrite_info(
 	sqlite3 *db, hashtable_t *ht,
 	lua_modprobe_overwrite_info_array *modprobe_overwrite_info_arr,
 	int tgid);
+int select_all_process_lpe_info(sqlite3 *db, hashtable_t *ht,
+				lua_process_lpe_info_array *process_lpe_info_arr,
+				int tgid);
 #endif // DATABASE_H

--- a/kalbur/rule_engine/database/database.h
+++ b/kalbur/rule_engine/database/database.h
@@ -23,6 +23,8 @@ typedef struct lua_ptrace_info_array lua_ptrace_info_array;
 typedef struct lua_socket_create_info_array lua_socket_create_info_array;
 typedef struct lua_tcp_connection_info_array lua_tcp_connection_info_array;
 typedef struct lua_module_load_info_array lua_module_load_info_array;
+typedef struct lua_modprobe_overwrite_info_array
+	lua_modprobe_overwrite_info_array;
 
 int create_connection(char *dbname, sqlite3 **db, int inmem);
 int initialize_database(char *dbname);
@@ -67,4 +69,8 @@ int select_all_tcp_connection_info(
 int select_all_module_load_info(sqlite3 *db, hashtable_t *ht,
 				lua_module_load_info_array *module_load_info_arr,
 				int tgid);
+int select_all_modprobe_overwrite_info(
+	sqlite3 *db, hashtable_t *ht,
+	lua_modprobe_overwrite_info_array *modprobe_overwrite_info_arr,
+	int tgid);
 #endif // DATABASE_H

--- a/kalbur/rule_engine/database/helper_defs.h
+++ b/kalbur/rule_engine/database/helper_defs.h
@@ -49,4 +49,11 @@
 		}                                                              \
 	} while (0)
 
+#define SQLITE3_GET(dest, type, index)                                         \
+	_Pragma(STRINGIFY(GCC diagnostic push)) _Pragma(                       \
+		STRINGIFY(GCC diagnostic ignored "-Wtraditional-conversion"))  \
+		_Pragma(STRINGIFY(GCC diagnostic ignored "-Wsign-conversion")) \
+			dest = sqlite3_column_##type(ppStmt, index);           \
+	_Pragma(STRINGIFY(GCC diagnostic pop))
+
 #endif // HELPER_DEFS_H

--- a/kalbur/rule_engine/database/schema.h
+++ b/kalbur/rule_engine/database/schema.h
@@ -20,7 +20,8 @@
 
 // Columns
 #define EVENT_TIME "event_time"
-#define TGID_PID "tgid_pid"
+#define TGID "tgid"
+#define PID "pid"
 #define SYSCALL "syscall"
 #define COMM "process_name"
 #define EVENT_ID "event_id" // alias for rowid
@@ -30,7 +31,8 @@
 	"CREATE TABLE events( \
 				" EVENT_ID " INTEGER PRIMARY KEY, \
 				" EVENT_TIME " UINT64_T NOT NULL, \
-				" TGID_PID " UINT64_T NOT NULL, \
+				" TGID " UINT64_T NOT NULL, \
+				" PID " UINT64_T NOT NULL, \
 				" SYSCALL " INTEGER NOT NULL, \
 				" COMM " TEXT \
 		      	);"
@@ -78,7 +80,8 @@
 /* Process info table */
 
 // Columns
-#define PPID "ppid"
+#define PARENT_TGID "parent_tgid"
+#define PARENT_PID "parent_pid"
 #define ARGS "args"
 #define INTERPRETER "interpreter"
 #define UID "uid"
@@ -96,9 +99,10 @@
 
 #define PROCESS_INFO_TABLE                                                     \
 	"CREATE TABLE process_info(						\
-		" EVENT_ID                                                     \
-	" INTEGER PRIMARY KEY, 				\
-		" PPID                                                         \
+		" EVENT_ID " INTEGER PRIMARY KEY, 				\
+		" PARENT_TGID                                                         \
+	" UINT64_T,						\
+		" PARENT_PID                                                         \
 	" UINT64_T,						\
 		" CLONE_FLAGS                                                  \
 	" UINT64_T, 					\

--- a/kalbur/rule_engine/database/schema.h
+++ b/kalbur/rule_engine/database/schema.h
@@ -99,10 +99,11 @@
 
 #define PROCESS_INFO_TABLE                                                     \
 	"CREATE TABLE process_info(						\
-		" EVENT_ID " INTEGER PRIMARY KEY, 				\
-		" PARENT_TGID                                                         \
+		" EVENT_ID                                                     \
+	" INTEGER PRIMARY KEY, 				\
+		" PARENT_TGID                                                  \
 	" UINT64_T,						\
-		" PARENT_PID                                                         \
+		" PARENT_PID                                                   \
 	" UINT64_T,						\
 		" CLONE_FLAGS                                                  \
 	" UINT64_T, 					\
@@ -192,14 +193,16 @@
 /* ptrace event table */
 #define REQUEST "request"
 #define ADDR "address"
-#define TARGET "target_tgid_pid"
+#define TARGET_TGID "target_tgid"
+#define TARGET_PID "target_pid"
 
 #define PTRACE_TABLE                                                           \
 	"CREATE table ptrace_event(\
 			" EVENT_ID " INTEGER PRIMARY KEY, \
 			" REQUEST " UINT64_T,\
 			" ADDR " UINT64_T,\
-			" TARGET " UINT64_T,\
+			" TARGET_TGID " UINT64_T,\
+			" TARGET_PID " UINT64_T,\
 			FOREIGN KEY(" EVENT_ID ") REFERENCES events(" EVENT_ID \
 	")\
 			);"

--- a/kalbur/rule_engine/database/stmts.h
+++ b/kalbur/rule_engine/database/stmts.h
@@ -206,6 +206,12 @@ unsigned char SELECT_MODPROBE_OVERWRITE_INFO[] =
 	" FROM events E1 JOIN modprobe_overwrite_info E2 ON E1." EVENT_ID
 	" = E2." EVENT_ID " WHERE E1." TGID " = :" TGID ";";
 
+unsigned char SELECT_PROCESS_LPE_INFO[] =
+	"SELECT E1." EVENT_TIME ", E1." SYSCALL ", E1." COMM
+	", E2." CALLER_RET_ADDR ", E2." TARGET_FUNC
+	" FROM events E1 JOIN lpe E2 ON E1." EVENT_ID " ="
+	" E2." EVENT_ID " WHERE E1." TGID " = :" TGID ";";
+
 unsigned char BEGIN_STMT[] = "BEGIN;";
 unsigned char ROLLBACK_STMT[] = "ROLLBACK;";
 unsigned char COMMIT_STMT[] = "COMMIT;";
@@ -252,6 +258,7 @@ const stmt_t SQL_STMTS[] = {
 	{ SELECT_MODULE_LOAD_INFO, sizeof(SELECT_MODULE_LOAD_INFO) },
 	{ SELECT_MODPROBE_OVERWRITE_INFO,
 	  sizeof(SELECT_MODPROBE_OVERWRITE_INFO) },
+	{ SELECT_PROCESS_LPE_INFO, sizeof(SELECT_PROCESS_LPE_INFO) },
 	// Misc sql statements
 	{ ROLLBACK_STMT, sizeof(ROLLBACK_STMT) },
 	{ COMMIT_STMT, sizeof(COMMIT_STMT) },

--- a/kalbur/rule_engine/database/stmts.h
+++ b/kalbur/rule_engine/database/stmts.h
@@ -194,6 +194,13 @@ unsigned char SELECT_TCP_CONNECTION_INFO[] =
 	" FROM events E1 JOIN tcp_connection_info E2 ON E1." EVENT_ID
 	" = E2." EVENT_ID " WHERE E1." TGID " = :" TGID ";";
 
+unsigned char SELECT_MODULE_LOAD_INFO[] =
+	"SELECT E1." EVENT_TIME ", E1." SYSCALL ", E1." COMM ", E3." FILENAME
+	", E3." INODE_NUMBER ", E3." S_MAGIC
+	" FROM events E1 JOIN module_load E2 ON E1." EVENT_ID
+	" = E2." EVENT_ID " JOIN file_info E3 ON E2." FILE_ID " = E3." FILE_ID
+	" WHERE E1." TGID " = :" TGID ";";
+
 unsigned char BEGIN_STMT[] = "BEGIN;";
 unsigned char ROLLBACK_STMT[] = "ROLLBACK;";
 unsigned char COMMIT_STMT[] = "COMMIT;";
@@ -237,6 +244,7 @@ const stmt_t SQL_STMTS[] = {
 	{ SELECT_PTRACE_INFO, sizeof(SELECT_PTRACE_INFO) },
 	{ SELECT_SOCKET_CREATE_INFO, sizeof(SELECT_SOCKET_CREATE_INFO) },
 	{ SELECT_TCP_CONNECTION_INFO, sizeof(SELECT_TCP_CONNECTION_INFO) },
+	{ SELECT_MODULE_LOAD_INFO, sizeof(SELECT_MODULE_LOAD_INFO) },
 	// Misc sql statements
 	{ ROLLBACK_STMT, sizeof(ROLLBACK_STMT) },
 	{ COMMIT_STMT, sizeof(COMMIT_STMT) },

--- a/kalbur/rule_engine/database/stmts.h
+++ b/kalbur/rule_engine/database/stmts.h
@@ -94,8 +94,9 @@ unsigned char INSERT_LPE_INFO[] =
 	") VALUES (:" EVENT_ID ",:" CALLER_RET_ADDR ",:" TARGET_FUNC ");";
 
 unsigned char INSERT_PTRACE_INFO[] =
-	"INSERT INTO ptrace_event(" EVENT_ID "," REQUEST "," ADDR "," TARGET
-	") VALUES(:" EVENT_ID ",:" REQUEST ",:" ADDR ",:" TARGET ");";
+	"INSERT INTO ptrace_event(" EVENT_ID "," REQUEST "," ADDR
+	"," TARGET_TGID "," TARGET_PID ") VALUES(:" EVENT_ID ",:" REQUEST
+	",:" ADDR ",:" TARGET_TGID ",:" TARGET_PID ");";
 
 unsigned char INSERT_MODULE_INFO[] =
 	"INSERT INTO module_load(" EVENT_ID "," FILE_ID ") VALUES(:" EVENT_ID
@@ -174,6 +175,12 @@ unsigned char SELECT_MMAP_INFO[] =
 	" ON E1." EVENT_ID " = E2." EVENT_ID " JOIN file_info E3 ON E2." FILE_ID
 	" = E3." FILE_ID " WHERE E1." TGID " = :" TGID ";";
 
+unsigned char SELECT_PTRACE_INFO[] =
+	"SELECT E1." EVENT_TIME ", E1." SYSCALL ", E1." COMM ", E2." REQUEST
+	", E2." ADDR ", E2." TARGET_TGID " FROM events E1"
+	" JOIN ptrace_event E2 ON E1." EVENT_ID " = E2." EVENT_ID " WHERE"
+	" E1." TGID " = :" TGID ";";
+
 unsigned char BEGIN_STMT[] = "BEGIN;";
 unsigned char ROLLBACK_STMT[] = "ROLLBACK;";
 unsigned char COMMIT_STMT[] = "COMMIT;";
@@ -214,6 +221,7 @@ const stmt_t SQL_STMTS[] = {
 	// Join statements
 	{ SELECT_PROCESS_INFO, sizeof(SELECT_PROCESS_INFO) },
 	{ SELECT_MMAP_INFO, sizeof(SELECT_MMAP_INFO) },
+	{ SELECT_PTRACE_INFO, sizeof(SELECT_PTRACE_INFO) },
 	// Misc sql statements
 	{ ROLLBACK_STMT, sizeof(ROLLBACK_STMT) },
 	{ COMMIT_STMT, sizeof(COMMIT_STMT) },

--- a/kalbur/rule_engine/database/stmts.h
+++ b/kalbur/rule_engine/database/stmts.h
@@ -187,6 +187,13 @@ unsigned char SELECT_SOCKET_CREATE_INFO[] =
 	" FROM events E1 JOIN socket_create_info E2"
 	" ON E1." EVENT_ID " = E2." EVENT_ID " WHERE E1." TGID " = :" TGID ";";
 
+unsigned char SELECT_TCP_CONNECTION_INFO[] =
+	"SELECT E1." EVENT_TIME ", E1." SYSCALL ", E1." COMM ", E2." TYPE
+	", E2." SADDR ", E2." SPORT ", E2." DADDR ", E2." DPORT
+	", E2." DIRECTION ", E2." SOCK_INODE
+	" FROM events E1 JOIN tcp_connection_info E2 ON E1." EVENT_ID
+	" = E2." EVENT_ID " WHERE E1." TGID " = :" TGID ";";
+
 unsigned char BEGIN_STMT[] = "BEGIN;";
 unsigned char ROLLBACK_STMT[] = "ROLLBACK;";
 unsigned char COMMIT_STMT[] = "COMMIT;";
@@ -229,6 +236,7 @@ const stmt_t SQL_STMTS[] = {
 	{ SELECT_MMAP_INFO, sizeof(SELECT_MMAP_INFO) },
 	{ SELECT_PTRACE_INFO, sizeof(SELECT_PTRACE_INFO) },
 	{ SELECT_SOCKET_CREATE_INFO, sizeof(SELECT_SOCKET_CREATE_INFO) },
+	{ SELECT_TCP_CONNECTION_INFO, sizeof(SELECT_TCP_CONNECTION_INFO) },
 	// Misc sql statements
 	{ ROLLBACK_STMT, sizeof(ROLLBACK_STMT) },
 	{ COMMIT_STMT, sizeof(COMMIT_STMT) },

--- a/kalbur/rule_engine/database/stmts.h
+++ b/kalbur/rule_engine/database/stmts.h
@@ -66,14 +66,15 @@ unsigned char INSERT_PROC_MMAP[] = "INSERT INTO proc_mmap(\
 
 unsigned char INSERT_PROCESS_INFO[] =
 	"INSERT INTO process_info(\
-					" EVENT_ID "," PARENT_TGID "," PARENT_PID "," CLONE_FLAGS
-	"," FILE_ID "," ARGS "," ENV "," INTERPRETER "," UID "," GID "," EUID
-	"," EGID "," STDIN_INODE "," STDIN_TYPE "," STDOUT_INODE "," STDOUT_TYPE
-	"," STDERR_INODE "," STDERR_TYPE ") VALUES(:" EVENT_ID ",:" PARENT_TGID
-	",:" PARENT_PID ",:" CLONE_FLAGS ",:" FILE_ID ",:" ARGS ",:" ENV
-	",:" INTERPRETER ",:" UID ",:" GID ",:" EUID ",:" EGID ",:" STDIN_INODE
-	",:" STDIN_TYPE ",:" STDOUT_INODE ",:" STDOUT_TYPE ",:" STDERR_INODE 
-	",:" STDERR_TYPE ");";
+					" EVENT_ID "," PARENT_TGID
+	"," PARENT_PID "," CLONE_FLAGS "," FILE_ID "," ARGS "," ENV
+	"," INTERPRETER "," UID "," GID "," EUID "," EGID "," STDIN_INODE
+	"," STDIN_TYPE "," STDOUT_INODE "," STDOUT_TYPE "," STDERR_INODE
+	"," STDERR_TYPE ") VALUES(:" EVENT_ID ",:" PARENT_TGID ",:" PARENT_PID
+	",:" CLONE_FLAGS ",:" FILE_ID ",:" ARGS ",:" ENV ",:" INTERPRETER
+	",:" UID ",:" GID ",:" EUID ",:" EGID ",:" STDIN_INODE ",:" STDIN_TYPE
+	",:" STDOUT_INODE ",:" STDOUT_TYPE ",:" STDERR_INODE ",:" STDERR_TYPE
+	");";
 
 unsigned char INSERT_SOCKET_CREATE_INFO[] =
 	"INSERT INTO socket_create_info(\
@@ -155,6 +156,24 @@ unsigned char SELECT_COMM_BY_EVENT_ID[] =
 unsigned char SELECT_COMM[] =
 	"SELECT " COMM " FROM disallowed WHERE " COMM " = :" COMM ";";
 
+unsigned char SELECT_PROCESS_INFO[] =
+	"SELECT E1." EVENT_TIME ", E1." SYSCALL ", E1." COMM ", E2." PARENT_TGID
+	", E2." CLONE_FLAGS ", E2." ARGS ", E2." ENV ", E2." INTERPRETER
+	", E2." UID ", E2." GID ", E2." EUID ", E2." EGID ", E2." STDIN_INODE
+	", E2." STDIN_TYPE ", E2." STDOUT_INODE ", E2." STDOUT_TYPE
+	", E2." STDERR_INODE ", E2." STDERR_TYPE ", E3." FILENAME
+	", E3." INODE_NUMBER ", E3." S_MAGIC " FROM events E1"
+	" JOIN process_info E2 ON E1." EVENT_ID " = E2." EVENT_ID
+	" JOIN file_info E3 ON E2." FILE_ID " = E3." FILE_ID " WHERE E1." TGID
+	" = :" TGID ";";
+
+unsigned char SELECT_MMAP_INFO[] =
+	"SELECT E1." EVENT_TIME ", E1." SYSCALL ", E1." COMM ", E2." VM_BASE
+	", E2." VM_FLAGS ", E2." VM_PROT ", E2." VM_LEN ", E3." FILENAME
+	", E3." INODE_NUMBER ", E3." S_MAGIC " FROM events E1 JOIN proc_mmap E2"
+	" ON E1." EVENT_ID " = E2." EVENT_ID " JOIN file_info E3 ON E2." FILE_ID
+	" = E3." FILE_ID " WHERE E1." TGID " = :" TGID ";";
+
 unsigned char BEGIN_STMT[] = "BEGIN;";
 unsigned char ROLLBACK_STMT[] = "ROLLBACK;";
 unsigned char COMMIT_STMT[] = "COMMIT;";
@@ -192,6 +211,9 @@ const stmt_t SQL_STMTS[] = {
 	{ SELECT_VM_INFO_BY_EVENT_ID, sizeof(SELECT_VM_INFO_BY_EVENT_ID) },
 	{ SELECT_COMM_BY_EVENT_ID, sizeof(SELECT_COMM_BY_EVENT_ID) },
 	{ SELECT_COMM, sizeof(SELECT_COMM) },
+	// Join statements
+	{ SELECT_PROCESS_INFO, sizeof(SELECT_PROCESS_INFO) },
+	{ SELECT_MMAP_INFO, sizeof(SELECT_MMAP_INFO) },
 	// Misc sql statements
 	{ ROLLBACK_STMT, sizeof(ROLLBACK_STMT) },
 	{ COMMIT_STMT, sizeof(COMMIT_STMT) },

--- a/kalbur/rule_engine/database/stmts.h
+++ b/kalbur/rule_engine/database/stmts.h
@@ -197,9 +197,14 @@ unsigned char SELECT_TCP_CONNECTION_INFO[] =
 unsigned char SELECT_MODULE_LOAD_INFO[] =
 	"SELECT E1." EVENT_TIME ", E1." SYSCALL ", E1." COMM ", E3." FILENAME
 	", E3." INODE_NUMBER ", E3." S_MAGIC
-	" FROM events E1 JOIN module_load E2 ON E1." EVENT_ID
-	" = E2." EVENT_ID " JOIN file_info E3 ON E2." FILE_ID " = E3." FILE_ID
-	" WHERE E1." TGID " = :" TGID ";";
+	" FROM events E1 JOIN module_load E2 ON E1." EVENT_ID " = E2." EVENT_ID
+	" JOIN file_info E3 ON E2." FILE_ID " = E3." FILE_ID " WHERE E1." TGID
+	" = :" TGID ";";
+
+unsigned char SELECT_MODPROBE_OVERWRITE_INFO[] =
+	"SELECT E1." EVENT_TIME ", E1." SYSCALL ", E1." COMM ", E2." PATH_NAME
+	" FROM events E1 JOIN modprobe_overwrite_info E2 ON E1." EVENT_ID
+	" = E2." EVENT_ID " WHERE E1." TGID " = :" TGID ";";
 
 unsigned char BEGIN_STMT[] = "BEGIN;";
 unsigned char ROLLBACK_STMT[] = "ROLLBACK;";
@@ -245,6 +250,8 @@ const stmt_t SQL_STMTS[] = {
 	{ SELECT_SOCKET_CREATE_INFO, sizeof(SELECT_SOCKET_CREATE_INFO) },
 	{ SELECT_TCP_CONNECTION_INFO, sizeof(SELECT_TCP_CONNECTION_INFO) },
 	{ SELECT_MODULE_LOAD_INFO, sizeof(SELECT_MODULE_LOAD_INFO) },
+	{ SELECT_MODPROBE_OVERWRITE_INFO,
+	  sizeof(SELECT_MODPROBE_OVERWRITE_INFO) },
 	// Misc sql statements
 	{ ROLLBACK_STMT, sizeof(ROLLBACK_STMT) },
 	{ COMMIT_STMT, sizeof(COMMIT_STMT) },

--- a/kalbur/rule_engine/database/stmts.h
+++ b/kalbur/rule_engine/database/stmts.h
@@ -42,11 +42,12 @@ const char *CREATE_STMTS[] = {
 // #### SQL STATEMENTS ####
 // ########################
 
-unsigned char INSERT_EVENT[] = "INSERT INTO events(\
-				" EVENT_TIME "," TGID_PID "," SYSCALL "," COMM
-			       ") \
-				VALUES(:" EVENT_TIME ",:" TGID_PID ",:" SYSCALL
-			       ",:" COMM ") RETURNING " EVENT_ID ";";
+unsigned char INSERT_EVENT[] =
+	"INSERT INTO events(\
+				" EVENT_TIME "," TGID "," PID "," SYSCALL
+	"," COMM ") \
+				VALUES(:" EVENT_TIME ",:" TGID ",:" PID
+	",:" SYSCALL ",:" COMM ") RETURNING " EVENT_ID ";";
 
 unsigned char INSERT_FILE_INFO[] = "INSERT INTO file_info(\
 					" FILENAME "," INODE_NUMBER "," S_MAGIC
@@ -65,14 +66,14 @@ unsigned char INSERT_PROC_MMAP[] = "INSERT INTO proc_mmap(\
 
 unsigned char INSERT_PROCESS_INFO[] =
 	"INSERT INTO process_info(\
-					" EVENT_ID "," PPID "," CLONE_FLAGS
+					" EVENT_ID "," PARENT_TGID "," PARENT_PID "," CLONE_FLAGS
 	"," FILE_ID "," ARGS "," ENV "," INTERPRETER "," UID "," GID "," EUID
 	"," EGID "," STDIN_INODE "," STDIN_TYPE "," STDOUT_INODE "," STDOUT_TYPE
-	"," STDERR_INODE "," STDERR_TYPE ") VALUES(:" EVENT_ID ",:" PPID
-	",:" CLONE_FLAGS ",:" FILE_ID ",:" ARGS ",:" ENV ",:" INTERPRETER
-	",:" UID ",:" GID ",:" EUID ",:" EGID ",:" STDIN_INODE ",:" STDIN_TYPE
-	",:" STDOUT_INODE ",:" STDOUT_TYPE ",:" STDERR_INODE ",:" STDERR_TYPE
-	");";
+	"," STDERR_INODE "," STDERR_TYPE ") VALUES(:" EVENT_ID ",:" PARENT_TGID
+	",:" PARENT_PID ",:" CLONE_FLAGS ",:" FILE_ID ",:" ARGS ",:" ENV
+	",:" INTERPRETER ",:" UID ",:" GID ",:" EUID ",:" EGID ",:" STDIN_INODE
+	",:" STDIN_TYPE ",:" STDOUT_INODE ",:" STDOUT_TYPE ",:" STDERR_INODE 
+	",:" STDERR_TYPE ");";
 
 unsigned char INSERT_SOCKET_CREATE_INFO[] =
 	"INSERT INTO socket_create_info(\
@@ -133,15 +134,16 @@ unsigned char SELECT_STDIN_BY_STDOUT[] =
 	" from process_info WHERE " STDIN_INODE " = :" STDIN_INODE ";";
 
 unsigned char SELECT_TGID_BY_EVENT_ID[] =
-	"SELECT " TGID_PID " from events WHERE " EVENT_ID " = :" EVENT_ID ";";
+	"SELECT " TGID ", " PID " from events WHERE " EVENT_ID " = :" EVENT_ID
+	";";
 
 unsigned char SELECT_IF_SOCK_CONN_EXISTS[] =
-	"SELECT " EVENT_ID " FROM events WHERE " TGID_PID " = :" TGID_PID
-	" and syscall = 41;";
+	"SELECT " EVENT_ID " FROM events WHERE " TGID " = :" TGID " AND " PID
+	" = :" PID " and syscall = 41;";
 
 unsigned char SELECT_EVENT_IDS_BY_TGID[] =
-	"SELECT " EVENT_ID " FROM events where TGID_PID = :" TGID_PID
-	" and (syscall = 9 or syscall = 59);";
+	"SELECT " EVENT_ID " FROM events where " TGID " = :" TGID " AND " PID
+	" = :" PID " and (syscall = 9 or syscall = 59);";
 
 unsigned char SELECT_VM_INFO_BY_EVENT_ID[] =
 	"SELECT " VM_BASE ", " VM_LEN ", " VM_PROT

--- a/kalbur/rule_engine/database/stmts.h
+++ b/kalbur/rule_engine/database/stmts.h
@@ -181,6 +181,12 @@ unsigned char SELECT_PTRACE_INFO[] =
 	" JOIN ptrace_event E2 ON E1." EVENT_ID " = E2." EVENT_ID " WHERE"
 	" E1." TGID " = :" TGID ";";
 
+unsigned char SELECT_SOCKET_CREATE_INFO[] =
+	"SELECT E1." EVENT_TIME ", E1." SYSCALL ", E1." COMM
+	", E2." INODE_NUMBER ", E2." FAMILY ", E2." SOCK_TYPE
+	" FROM events E1 JOIN socket_create_info E2"
+	" ON E1." EVENT_ID " = E2." EVENT_ID " WHERE E1." TGID " = :" TGID ";";
+
 unsigned char BEGIN_STMT[] = "BEGIN;";
 unsigned char ROLLBACK_STMT[] = "ROLLBACK;";
 unsigned char COMMIT_STMT[] = "COMMIT;";
@@ -222,6 +228,7 @@ const stmt_t SQL_STMTS[] = {
 	{ SELECT_PROCESS_INFO, sizeof(SELECT_PROCESS_INFO) },
 	{ SELECT_MMAP_INFO, sizeof(SELECT_MMAP_INFO) },
 	{ SELECT_PTRACE_INFO, sizeof(SELECT_PTRACE_INFO) },
+	{ SELECT_SOCKET_CREATE_INFO, sizeof(SELECT_SOCKET_CREATE_INFO) },
 	// Misc sql statements
 	{ ROLLBACK_STMT, sizeof(ROLLBACK_STMT) },
 	{ COMMIT_STMT, sizeof(COMMIT_STMT) },

--- a/kalbur/rule_engine/engine.c
+++ b/kalbur/rule_engine/engine.c
@@ -51,7 +51,7 @@ void process_message(struct message_state *ms, struct engine *e)
 
 	if (should_process_rules(ms)) {
 		ASSERT(ms->event_id, "process_message: ms->event_id == 0");
-		err = apply_rules(e->le, ms);
+		err = apply_rules(e, ms);
 		transition_ms_progress(ms, MS_RULES_PROCESSED, err);
 	}
 

--- a/kalbur/rule_engine/lua/Makefile
+++ b/kalbur/rule_engine/lua/Makefile
@@ -14,6 +14,7 @@ EVENT_INFO := lua_event_info
 FILE_INFO := lua_file_info
 PROCESS_INFO := lua_process_info
 MMAP_INFO := lua_mmap_info
+PTRACE_INFO := lua_ptrace_info
 
 all: $(ENGINE).o \
 	$(EVENT).o \
@@ -25,6 +26,7 @@ all: $(ENGINE).o \
 	$(FILE_INFO).o \
 	$(PROCESS_INFO).o \
 	$(MMAP_INFO).o \
+	$(PTRACE_INFO).o \
 
 $(ENGINE).o: $(ENGINE).c $(ENGINE).h
 	$(call msg,LUA_ENGINE,$@)
@@ -65,6 +67,10 @@ $(PROCESS_INFO).o: $(PROCESS_INFO).c $(PROCESS_INFO).h
 $(MMAP_INFO).o: $(MMAP_INFO).c $(MMAP_INFO).h
 	$(call msg,LUA_MMAP_INFO,$@)
 	$(Q)$(CC) -DAPPLY_ASSERT $(DEBUG_FLAG) $(CFLAGS) $(INCLUDES) -c $(MMAP_INFO).c -o $@
+
+$(PTRACE_INFO).o: $(PTRACE_INFO).c $(PTRACE_INFO).h
+	$(call msg,LUA_PTRACE_INFO,$@)
+	$(Q)$(CC) -DAPPLY_ASSERT $(DEBUG_FLAG) $(CFLAGS) $(INCLUDES) -c $(PTRACE_INFO).c -o $@
 
 clean:
 	$(call msg,CLEAN)

--- a/kalbur/rule_engine/lua/Makefile
+++ b/kalbur/rule_engine/lua/Makefile
@@ -18,6 +18,7 @@ PTRACE_INFO := lua_ptrace_info
 SOCKET_CREATE_INFO := lua_socket_create_info
 TCP_CONNECTION_INFO := lua_tcp_connection_info
 MODULE_LOAD_INFO := lua_module_load_info
+MODPROBE_OVERWRITE_INFO := lua_modprobe_overwrite_info
 
 all: $(ENGINE).o \
 	$(EVENT).o \
@@ -33,6 +34,7 @@ all: $(ENGINE).o \
 	$(SOCKET_CREATE_INFO).o \
 	$(TCP_CONNECTION_INFO).o \
 	$(MODULE_LOAD_INFO).o \
+	$(MODPROBE_OVERWRITE_INFO).o \
 
 $(ENGINE).o: $(ENGINE).c $(ENGINE).h
 	$(call msg,LUA_ENGINE,$@)
@@ -89,6 +91,10 @@ $(TCP_CONNECTION_INFO).o: $(TCP_CONNECTION_INFO).c $(TCP_CONNECTION_INFO).h
 $(MODULE_LOAD_INFO).o: $(MODULE_LOAD_INFO).c $(MODULE_LOAD_INFO).h
 	$(call msg,LUA_MODULE_LOAD_INFO,$@)
 	$(Q)$(CC) -DAPPLY_ASSERT $(DEBUG_FLAG) $(CFLAGS) $(INCLUDES) -c $(MODULE_LOAD_INFO).c -o $@
+
+$(MODPROBE_OVERWRITE_INFO).o: $(MODPROBE_OVERWRITE_INFO).c $(MODPROBE_OVERWRITE_INFO).h
+	$(call msg,LUA_MODPROBE_OVERWRITE_INFO,$@)
+	$(Q)$(CC) -DAPPLY_ASSERT $(DEBUG_FLAG) $(CFLAGS) $(INCLUDES) -c $(MODPROBE_OVERWRITE_INFO).c -o $@
 
 clean:
 	$(call msg,CLEAN)

--- a/kalbur/rule_engine/lua/Makefile
+++ b/kalbur/rule_engine/lua/Makefile
@@ -17,6 +17,7 @@ MMAP_INFO := lua_mmap_info
 PTRACE_INFO := lua_ptrace_info
 SOCKET_CREATE_INFO := lua_socket_create_info
 TCP_CONNECTION_INFO := lua_tcp_connection_info
+MODULE_LOAD_INFO := lua_module_load_info
 
 all: $(ENGINE).o \
 	$(EVENT).o \
@@ -31,6 +32,7 @@ all: $(ENGINE).o \
 	$(PTRACE_INFO).o \
 	$(SOCKET_CREATE_INFO).o \
 	$(TCP_CONNECTION_INFO).o \
+	$(MODULE_LOAD_INFO).o \
 
 $(ENGINE).o: $(ENGINE).c $(ENGINE).h
 	$(call msg,LUA_ENGINE,$@)
@@ -83,6 +85,10 @@ $(SOCKET_CREATE_INFO).o: $(SOCKET_CREATE_INFO).c $(SOCKET_CREATE_INFO).h
 $(TCP_CONNECTION_INFO).o: $(TCP_CONNECTION_INFO).c $(TCP_CONNECTION_INFO).h
 	$(call msg,LUA_TCP_CONNECTION_INFO,$@)
 	$(Q)$(CC) -DAPPLY_ASSERT $(DEBUG_FLAG) $(CFLAGS) $(INCLUDES) -c $(TCP_CONNECTION_INFO).c -o $@
+
+$(MODULE_LOAD_INFO).o: $(MODULE_LOAD_INFO).c $(MODULE_LOAD_INFO).h
+	$(call msg,LUA_MODULE_LOAD_INFO,$@)
+	$(Q)$(CC) -DAPPLY_ASSERT $(DEBUG_FLAG) $(CFLAGS) $(INCLUDES) -c $(MODULE_LOAD_INFO).c -o $@
 
 clean:
 	$(call msg,CLEAN)

--- a/kalbur/rule_engine/lua/Makefile
+++ b/kalbur/rule_engine/lua/Makefile
@@ -15,6 +15,7 @@ FILE_INFO := lua_file_info
 PROCESS_INFO := lua_process_info
 MMAP_INFO := lua_mmap_info
 PTRACE_INFO := lua_ptrace_info
+SOCKET_CREATE_INFO := lua_socket_create_info
 
 all: $(ENGINE).o \
 	$(EVENT).o \
@@ -27,6 +28,7 @@ all: $(ENGINE).o \
 	$(PROCESS_INFO).o \
 	$(MMAP_INFO).o \
 	$(PTRACE_INFO).o \
+	$(SOCKET_CREATE_INFO).o \
 
 $(ENGINE).o: $(ENGINE).c $(ENGINE).h
 	$(call msg,LUA_ENGINE,$@)
@@ -71,6 +73,10 @@ $(MMAP_INFO).o: $(MMAP_INFO).c $(MMAP_INFO).h
 $(PTRACE_INFO).o: $(PTRACE_INFO).c $(PTRACE_INFO).h
 	$(call msg,LUA_PTRACE_INFO,$@)
 	$(Q)$(CC) -DAPPLY_ASSERT $(DEBUG_FLAG) $(CFLAGS) $(INCLUDES) -c $(PTRACE_INFO).c -o $@
+
+$(SOCKET_CREATE_INFO).o: $(SOCKET_CREATE_INFO).c $(SOCKET_CREATE_INFO).h
+	$(call msg,LUA_SOCKET_CREATE_INFO,$@)
+	$(Q)$(CC) -DAPPLY_ASSERT $(DEBUG_FLAG) $(CFLAGS) $(INCLUDES) -c $(SOCKET_CREATE_INFO).c -o $@
 
 clean:
 	$(call msg,CLEAN)

--- a/kalbur/rule_engine/lua/Makefile
+++ b/kalbur/rule_engine/lua/Makefile
@@ -16,6 +16,7 @@ PROCESS_INFO := lua_process_info
 MMAP_INFO := lua_mmap_info
 PTRACE_INFO := lua_ptrace_info
 SOCKET_CREATE_INFO := lua_socket_create_info
+TCP_CONNECTION_INFO := lua_tcp_connection_info
 
 all: $(ENGINE).o \
 	$(EVENT).o \
@@ -29,6 +30,7 @@ all: $(ENGINE).o \
 	$(MMAP_INFO).o \
 	$(PTRACE_INFO).o \
 	$(SOCKET_CREATE_INFO).o \
+	$(TCP_CONNECTION_INFO).o \
 
 $(ENGINE).o: $(ENGINE).c $(ENGINE).h
 	$(call msg,LUA_ENGINE,$@)
@@ -77,6 +79,10 @@ $(PTRACE_INFO).o: $(PTRACE_INFO).c $(PTRACE_INFO).h
 $(SOCKET_CREATE_INFO).o: $(SOCKET_CREATE_INFO).c $(SOCKET_CREATE_INFO).h
 	$(call msg,LUA_SOCKET_CREATE_INFO,$@)
 	$(Q)$(CC) -DAPPLY_ASSERT $(DEBUG_FLAG) $(CFLAGS) $(INCLUDES) -c $(SOCKET_CREATE_INFO).c -o $@
+
+$(TCP_CONNECTION_INFO).o: $(TCP_CONNECTION_INFO).c $(TCP_CONNECTION_INFO).h
+	$(call msg,LUA_TCP_CONNECTION_INFO,$@)
+	$(Q)$(CC) -DAPPLY_ASSERT $(DEBUG_FLAG) $(CFLAGS) $(INCLUDES) -c $(TCP_CONNECTION_INFO).c -o $@
 
 clean:
 	$(call msg,CLEAN)

--- a/kalbur/rule_engine/lua/Makefile
+++ b/kalbur/rule_engine/lua/Makefile
@@ -19,6 +19,7 @@ SOCKET_CREATE_INFO := lua_socket_create_info
 TCP_CONNECTION_INFO := lua_tcp_connection_info
 MODULE_LOAD_INFO := lua_module_load_info
 MODPROBE_OVERWRITE_INFO := lua_modprobe_overwrite_info
+PROCESS_LPE_INFO := lua_process_lpe_info
 
 all: $(ENGINE).o \
 	$(EVENT).o \
@@ -35,6 +36,7 @@ all: $(ENGINE).o \
 	$(TCP_CONNECTION_INFO).o \
 	$(MODULE_LOAD_INFO).o \
 	$(MODPROBE_OVERWRITE_INFO).o \
+	$(PROCESS_LPE_INFO).o \
 
 $(ENGINE).o: $(ENGINE).c $(ENGINE).h
 	$(call msg,LUA_ENGINE,$@)
@@ -95,6 +97,10 @@ $(MODULE_LOAD_INFO).o: $(MODULE_LOAD_INFO).c $(MODULE_LOAD_INFO).h
 $(MODPROBE_OVERWRITE_INFO).o: $(MODPROBE_OVERWRITE_INFO).c $(MODPROBE_OVERWRITE_INFO).h
 	$(call msg,LUA_MODPROBE_OVERWRITE_INFO,$@)
 	$(Q)$(CC) -DAPPLY_ASSERT $(DEBUG_FLAG) $(CFLAGS) $(INCLUDES) -c $(MODPROBE_OVERWRITE_INFO).c -o $@
+
+$(PROCESS_LPE_INFO).o: $(PROCESS_LPE_INFO).c $(PROCESS_LPE_INFO).h
+	$(call msg,LUA_PROCESS_LPE_INFO,$@)
+	$(Q)$(CC) -DAPPLY_ASSERT $(DEBUG_FLAG) $(CFLAGS) $(INCLUDES) -c $(PROCESS_LPE_INFO).c -o $@
 
 clean:
 	$(call msg,CLEAN)

--- a/kalbur/rule_engine/lua/Makefile
+++ b/kalbur/rule_engine/lua/Makefile
@@ -4,12 +4,27 @@ include $(ROOT_DIR)/Makefile.inc
 
 ENGINE := lua_engine
 EVENT := lua_event
+PROCESS := lua_process
 ATTR_HANDLER := attr_handler
+PROCESS_ATTR_HANDLER := lua_process_attr_handler
 MANAGER := rule_manager
 HELPERS_FN := helpers_fn
 TAGS := lua_ms_tags
+EVENT_INFO := lua_event_info
+FILE_INFO := lua_file_info
+PROCESS_INFO := lua_process_info
+MMAP_INFO := lua_mmap_info
 
-all: $(ENGINE).o $(EVENT).o $(ATTR_HANDLER).o $(MANAGER).o $(TAGS).o
+all: $(ENGINE).o \
+	$(EVENT).o \
+	$(PROCESS).o \
+	$(ATTR_HANDLER).o \
+	$(MANAGER).o \
+	$(TAGS).o \
+	$(EVENT_INFO).o \
+	$(FILE_INFO).o \
+	$(PROCESS_INFO).o \
+	$(MMAP_INFO).o \
 
 $(ENGINE).o: $(ENGINE).c $(ENGINE).h
 	$(call msg,LUA_ENGINE,$@)
@@ -18,6 +33,10 @@ $(ENGINE).o: $(ENGINE).c $(ENGINE).h
 $(EVENT).o: $(EVENT).c $(EVENT).h
 	$(call msg,LUA_EVENT,$@)
 	$(Q)$(CC) -DAPPLY_ASSERT $(DEBUG_FLAG) $(CFLAGS) $(INCLUDES) -c $(EVENT).c -o $@
+
+$(PROCESS).o: $(PROCESS).c $(PROCESS).h
+	$(call msg,LUA_PROCESS,$@)
+	$(Q)$(CC) -DAPPLY_ASSERT $(DEBUG_FLAG) $(CFLAGS) $(INCLUDES) -c $(PROCESS).c -o $@
 
 $(ATTR_HANDLER).o: $(ATTR_HANDLER).c $(ATTR_HANDLER).h
 	$(call msg,ATTR_HANDLER,$@)
@@ -30,6 +49,22 @@ $(MANAGER).o: $(MANAGER).c $(MANAGER).h
 $(TAGS).o: $(TAGS).c $(TAGS).h
 	$(call msg,LUA_TAGS,$@)
 	$(Q)$(CC) -DAPPLY_ASSERT $(DEBUG_FLAG) $(CFLAGS) $(INCLUDES) -c $(TAGS).c -o $@
+
+$(EVENT_INFO).o: $(EVENT_INFO).c $(EVENT_INFO).h
+	$(call msg,LUA_EVENT_INFO,$@)
+	$(Q)$(CC) -DAPPLY_ASSERT $(DEBUG_FLAG) $(CFLAGS) $(INCLUDES) -c $(EVENT_INFO).c -o $@
+
+$(FILE_INFO).o: $(FILE_INFO).c $(FILE_INFO).h
+	$(call msg,LUA_FILE_INFO,$@)
+	$(Q)$(CC) -DAPPLY_ASSERT $(DEBUG_FLAG) $(CFLAGS) $(INCLUDES) -c $(FILE_INFO).c -o $@
+
+$(PROCESS_INFO).o: $(PROCESS_INFO).c $(PROCESS_INFO).h
+	$(call msg,LUA_PROCESS_INFO,$@)
+	$(Q)$(CC) -DAPPLY_ASSERT $(DEBUG_FLAG) $(CFLAGS) $(INCLUDES) -c $(PROCESS_INFO).c -o $@
+
+$(MMAP_INFO).o: $(MMAP_INFO).c $(MMAP_INFO).h
+	$(call msg,LUA_MMAP_INFO,$@)
+	$(Q)$(CC) -DAPPLY_ASSERT $(DEBUG_FLAG) $(CFLAGS) $(INCLUDES) -c $(MMAP_INFO).c -o $@
 
 clean:
 	$(call msg,CLEAN)

--- a/kalbur/rule_engine/lua/attr_handler.c
+++ b/kalbur/rule_engine/lua/attr_handler.c
@@ -16,14 +16,14 @@
 
 #define IS_ATTR(attr_name, attr) strncmp(attr_name, attr, sizeof(attr)) == 0
 
-#define TGID_PID "pid"
+#define PID "pid"
 #define EVENT_TIME "eventTime"
 #define COMM "processName"
 #define SYSCALL "syscall"
 static int push_event_header_attr(lua_State *L, const char *attr_name,
 				  struct probe_event_header *eh)
 {
-	if (IS_ATTR(attr_name, TGID_PID)) {
+	if (IS_ATTR(attr_name, PID)) {
 		lua_pushinteger(L, (long)(eh->tgid_pid >> 32));
 		return CODE_SUCCESS;
 	} else if (IS_ATTR(attr_name, EVENT_TIME)) {

--- a/kalbur/rule_engine/lua/lua_engine.c
+++ b/kalbur/rule_engine/lua/lua_engine.c
@@ -53,12 +53,13 @@ static void evaluate_rule_list(lua_State *L, struct rule_list *r)
 	}
 }
 
-int apply_rules(struct lua_engine *e, struct message_state *ms)
+int apply_rules(struct engine *e, struct message_state *ms)
 {
 	int event_indx;
 	struct probe_event_header *eh;
 	struct rule_list **event_rls;
 	struct rule_list *r;
+	struct lua_engine *le = e->le;
 
 	ASSERT(ms != NULL, "process_rule: ms == NULL");
 	ASSERT(ms->primary_data != NULL,
@@ -69,23 +70,23 @@ int apply_rules(struct lua_engine *e, struct message_state *ms)
 	if (event_indx == LUA_NONE)
 		return CODE_SUCCESS;
 
-	ASSERT(e->manager != NULL, "process_rule: manager == NULL");
-	event_rls = e->manager->event_rls;
+	ASSERT(le->manager != NULL, "process_rule: manager == NULL");
+	event_rls = le->manager->event_rls;
 	ASSERT(event_rls != NULL, "process_rule: event_rls == NULL");
 
-	setup_event_context(e->L, ms);
+	setup_event_context(le->L, ms);
 
 	// evaluate rule for any event
 	r = event_rls[LUA_ANY];
 	if (r != NULL)
-		evaluate_rule_list(e->L, r);
+		evaluate_rule_list(le->L, r);
 
 	// evaluate rule for specific event
 	r = event_rls[event_indx];
 	if (r != NULL)
-		evaluate_rule_list(e->L, r);
+		evaluate_rule_list(le->L, r);
 
-	teardown_event_context(e->L);
+	teardown_event_context(le->L);
 
 	return CODE_SUCCESS;
 }

--- a/kalbur/rule_engine/lua/lua_engine.c
+++ b/kalbur/rule_engine/lua/lua_engine.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <err.h>
 #include <lua_event.h>
+#include <lua_process.h>
 #include <syscall_defs.h>
 #include <message.h>
 #include <events.h>
@@ -75,6 +76,7 @@ int apply_rules(struct engine *e, struct message_state *ms)
 	ASSERT(event_rls != NULL, "process_rule: event_rls == NULL");
 
 	setup_event_context(le->L, ms);
+	init_process_context(le->L, e->db, e->sqlite_stmts);
 
 	// evaluate rule for any event
 	r = event_rls[LUA_ANY];
@@ -87,6 +89,7 @@ int apply_rules(struct engine *e, struct message_state *ms)
 		evaluate_rule_list(le->L, r);
 
 	teardown_event_context(le->L);
+	teardown_process_context(le->L);
 
 	return CODE_SUCCESS;
 }

--- a/kalbur/rule_engine/lua/lua_engine.h
+++ b/kalbur/rule_engine/lua/lua_engine.h
@@ -3,6 +3,7 @@
 
 #include "rule_manager.h"
 #include "engine.h"
+#include <lua_process.h>
 #include <lua.h>
 #include <message.h>
 

--- a/kalbur/rule_engine/lua/lua_engine.h
+++ b/kalbur/rule_engine/lua/lua_engine.h
@@ -2,6 +2,7 @@
 #define LUA_ENGINE_H
 
 #include "rule_manager.h"
+#include "engine.h"
 #include <lua.h>
 #include <message.h>
 
@@ -10,7 +11,7 @@ struct lua_engine {
 	struct rules_manager *manager;
 };
 
-int apply_rules(struct lua_engine *e, struct message_state *ms);
+int apply_rules(struct engine *e, struct message_state *ms);
 struct lua_engine *initialize_new_lua_engine(struct rules_manager *manager);
 struct rules_manager *init_rules_manager(char *config_file);
 

--- a/kalbur/rule_engine/lua/lua_event.c
+++ b/kalbur/rule_engine/lua/lua_event.c
@@ -28,7 +28,7 @@ static int event_index(lua_State *L)
 	}
 
 	ASSERT(event->push_attr != NULL,
-	       "event_index: event->push_att == NULL");
+	       "event_index: event->push_attr == NULL");
 	event->push_attr(L, attr, ms);
 
 	return 1;

--- a/kalbur/rule_engine/lua/lua_event_info.c
+++ b/kalbur/rule_engine/lua/lua_event_info.c
@@ -1,0 +1,21 @@
+#include "lua_event_info.h"
+
+/**
+ * @brief Frees lua_event_info
+ * 
+ * @param event_info 
+ */
+void delete_lua_event_info(struct lua_event_info *event_info)
+{
+	if (event_info == NULL) {
+		return;
+	}
+
+	if (event_info->process_name != NULL) {
+		free(event_info->process_name);
+		event_info->process_name = NULL;
+	}
+
+	free(event_info);
+	event_info = NULL;
+}

--- a/kalbur/rule_engine/lua/lua_event_info.h
+++ b/kalbur/rule_engine/lua/lua_event_info.h
@@ -1,0 +1,17 @@
+#ifndef LUA_EVENT_INFO_H
+#define LUA_EVENT_INFO_H
+
+#include <lua_process.h>
+
+#define EVENT_TIME "event_time"
+#define SYSCALL "syscall"
+#define PROCESS_NAME "process_name"
+struct lua_event_info {
+	u64_t event_time;
+	int syscall;
+	char *process_name;
+};
+
+void delete_lua_event_info(struct lua_event_info *event_info);
+
+#endif // LUA_EVENT_INFO_H

--- a/kalbur/rule_engine/lua/lua_file_info.c
+++ b/kalbur/rule_engine/lua/lua_file_info.c
@@ -1,0 +1,89 @@
+#include "lua_file_info.h"
+
+/**
+ * @brief Frees lua_file_info
+ * 
+ * @param event_info 
+ */
+void delete_lua_file_info(struct lua_file_info *file_info)
+{
+	if (file_info == NULL) {
+		return;
+	}
+
+	if (file_info->filename != NULL) {
+		free(file_info->filename);
+		file_info->filename = NULL;
+	}
+
+	free(file_info);
+	file_info = NULL;
+}
+
+/**
+ * @brief handle index access of file_info
+ * Expects stack to have string attribute at the top
+ * and file_info user data at position -2.
+ * returns nil if error occurs.
+ * 
+ * Stack: [-2, +1]
+ * @param L
+ * @return number of return values (1)
+ */
+int file_info_index(lua_State *L)
+{
+	struct lua_file_info *file_info;
+	const char *attribute;
+
+	ASSERT(lua_isuserdata(L, -2),
+	       "file_info_index: stack[-2] not userdata");
+
+	// make sure that the attribute is string
+	if (!lua_isstring(L, -1)) {
+		fprintf(stderr, "file_info_index: stack[-1] not string\n");
+		lua_pop(L, 2);
+		lua_pushnil(L);
+		return 1;
+	}
+
+	// get file_info light user data
+	lua_getuservalue(L, -2);
+	lua_pushstring(L, FILE_INFO);
+	lua_gettable(L, -2);
+	ASSERT(lua_isuserdata(L, -1),
+	       "file_info_index: file_info user value not found");
+
+	file_info = (struct lua_file_info *)lua_touserdata(L, -1);
+	ASSERT(file_info != NULL, "file_info_index: file_info is NULL");
+
+	lua_pop(L, 2);
+
+	// get string attribute
+	attribute = lua_tostring(L, -1);
+
+	// swap attribute and file_info user data
+	lua_rotate(L, -2, 1);
+	lua_pop(L, 2);
+
+	// handle attribute
+	if (IS_ATTR(attribute, FILENAME)) {
+		lua_pop(L, 1);
+		lua_pushstring(L, file_info->filename);
+		return 1;
+	} else if (IS_ATTR(attribute, INODE)) {
+		lua_pop(L, 1);
+		lua_pushinteger(L, (lua_Integer)file_info->inode);
+		return 1;
+	}
+	if (IS_ATTR(attribute, S_MAGIC)) {
+		lua_pop(L, 1);
+		lua_pushinteger(L, (lua_Integer)file_info->s_magic);
+		return 1;
+	} else {
+		fprintf(stderr, "file_info_index: invalid attribute: %s\n",
+			attribute);
+		lua_pop(L, 1);
+		lua_pushnil(L);
+		return 1;
+	}
+}

--- a/kalbur/rule_engine/lua/lua_file_info.h
+++ b/kalbur/rule_engine/lua/lua_file_info.h
@@ -1,0 +1,21 @@
+#ifndef LUA_FILE_INFO_H
+#define LUA_FILE_INFO_H
+
+#include <lua_process.h>
+
+#define FILE_INFO "FileInfo"
+#define FILE_INFO_METATABLE "FileInfoMetaTable"
+
+#define FILENAME "filename"
+#define INODE "inode"
+#define S_MAGIC "s_magic"
+struct lua_file_info {
+	char *filename;
+	u64_t inode;
+	u64_t s_magic;
+};
+
+void delete_lua_file_info(struct lua_file_info *file_info);
+int file_info_index(lua_State *L);
+
+#endif // LUA_FILE_INFO_H

--- a/kalbur/rule_engine/lua/lua_mmap_info.c
+++ b/kalbur/rule_engine/lua/lua_mmap_info.c
@@ -63,6 +63,18 @@ int mmap_info_index(lua_State *L)
 		lua_pop(L, 1);
 		lua_pushinteger(L, (lua_Integer)mmap_info->vm_base);
 		return 1;
+	} else if (IS_ATTR(attribute, VM_FLAGS)) {
+		lua_pop(L, 1);
+		lua_pushinteger(L, (lua_Integer)mmap_info->vm_flags);
+		return 1;
+	} else if (IS_ATTR(attribute, VM_PROT)) {
+		lua_pop(L, 1);
+		lua_pushinteger(L, (lua_Integer)mmap_info->vm_prot);
+		return 1;
+	} else if (IS_ATTR(attribute, VM_LEN)) {
+		lua_pop(L, 1);
+		lua_pushinteger(L, (lua_Integer)mmap_info->vm_len);
+		return 1;
 	} else if (IS_ATTR(attribute, FILE)) {
 		lua_pop(L, 1);
 		// stack is reset

--- a/kalbur/rule_engine/lua/lua_mmap_info.c
+++ b/kalbur/rule_engine/lua/lua_mmap_info.c
@@ -1,0 +1,340 @@
+#include "lua_mmap_info.h"
+
+/**
+ * @brief handle index access of mmap_info
+ * Expects stack to have string attribute at the top
+ * and mmap_info user data at position -2.
+ * returns nil if error occurs.
+ * 
+ * Stack: [-2, +1]
+ * @param L
+ * @return number of return values (1)
+ */
+int mmap_info_index(lua_State *L)
+{
+	struct lua_mmap_info *mmap_info;
+	const char *attribute;
+
+	ASSERT(lua_isuserdata(L, -2),
+	       "mmap_info_index: stack[-2] not userdata");
+
+	// make sure that the attribute is string
+	if (!lua_isstring(L, -1)) {
+		fprintf(stderr, "mmap_info_index: stack[-1] not string\n");
+		lua_pop(L, 2);
+		lua_pushnil(L);
+		return 1;
+	}
+
+	// get mmap_info light user data
+	lua_getuservalue(L, -2);
+	lua_pushstring(L, MMAP_INFO);
+	lua_gettable(L, -2);
+	ASSERT(lua_isuserdata(L, -1),
+	       "mmap_info_index: mmap_info user value not found");
+
+	mmap_info = (struct lua_mmap_info *)lua_touserdata(L, -1);
+	ASSERT(mmap_info != NULL, "mmap_info_index: mmap_info is NULL");
+
+	lua_pop(L, 2);
+
+	// get string attribute
+	attribute = lua_tostring(L, -1);
+
+	// swap attribute and mmap_info user data
+	lua_rotate(L, -2, 1);
+	lua_pop(L, 1);
+
+	// handle attribute
+	if (IS_ATTR(attribute, EVENT_TIME)) {
+		lua_pop(L, 1);
+		lua_pushinteger(L,
+				(lua_Integer)mmap_info->event_info->event_time);
+		return 1;
+	} else if (IS_ATTR(attribute, SYSCALL)) {
+		lua_pop(L, 1);
+		lua_pushinteger(L, (lua_Integer)mmap_info->event_info->syscall);
+		return 1;
+	} else if (IS_ATTR(attribute, PROCESS_NAME)) {
+		lua_pop(L, 1);
+		lua_pushstring(L, mmap_info->event_info->process_name);
+		return 1;
+	} else if (IS_ATTR(attribute, VM_BASE)) {
+		lua_pop(L, 1);
+		lua_pushinteger(L, (lua_Integer)mmap_info->vm_base);
+		return 1;
+	} else if (IS_ATTR(attribute, FILE)) {
+		lua_pop(L, 1);
+		// stack is reset
+
+		lua_newuserdata(L, sizeof(struct lua_file_info));
+
+		// stores file_info (light user data) in a table as user value
+		// file_info_full_ud.userdata["FILE_INFO"] = file_info_light_ud
+		lua_newtable(L);
+		lua_pushstring(L, FILE_INFO);
+		lua_pushlightuserdata(L, mmap_info->file_info);
+		lua_settable(L, -3);
+
+		lua_setuservalue(L, -2);
+
+		// create new metatable and set its metamethods
+		luaL_newmetatable(L, FILE_INFO_METATABLE);
+
+		lua_pushstring(L, "__index");
+		lua_pushcfunction(L, file_info_index);
+		lua_settable(L, -3);
+
+		// sanity checks
+		ASSERT(lua_istable(L, -1), "");
+		ASSERT(lua_isuserdata(L, -2), "");
+
+		// set metatable of process context
+		lua_setmetatable(L, -2);
+
+		// make sure that we return file_info userdata
+		ASSERT(lua_isuserdata(L, -1), "");
+
+		return 1;
+	} else {
+		fprintf(stderr, "mmap_info_index: invalid attribute: %s\n",
+			attribute);
+		lua_pop(L, 1);
+		lua_pushnil(L);
+		return 1;
+	}
+}
+
+/**
+ * @brief handle index access of mmap_info_arr
+ * Expects stack to have integer attribute at the top
+ * and proces_context user data at position -2.
+ * returns nil if error occurs.
+ * Stack: [-2, +1]
+ * 
+ * @param L 
+ * @return Number of return values (1)
+ */
+int mmap_info_arr_index(lua_State *L)
+{
+	struct lua_mmap_info_array *mmap_info_arr;
+	struct lua_mmap_info *mmap_info;
+	int index;
+
+	if (!lua_isinteger(L, -1)) {
+		fprintf(stderr, "mmap_info_arr_index: stack[-1] not integer\n");
+		lua_pop(L, 2);
+		lua_pushnil(L);
+		return 1;
+	}
+
+	// get the integer index
+	index = (int)lua_tointeger(L, -1);
+	ASSERT(lua_isuserdata(L, -2),
+	       "mmap_info_arr_index: stack[-2] not userdata");
+
+	// get mmap_info_arr_full_ud.userdata["MMAP_INFO_ARR"]
+	// which is the light ud
+	lua_getuservalue(L, -2);
+	ASSERT(lua_istable(L, -1), "mmap_info_arr_index: stack[-1] not table");
+	lua_pushstring(L, MMAP_INFO_ARR);
+	lua_gettable(L, -2);
+
+	mmap_info_arr = (struct lua_mmap_info_array *)lua_touserdata(L, -1);
+	ASSERT(mmap_info_arr != NULL,
+	       "mmap_info_arr_index: mmap_info_arr == NULL");
+
+	lua_pop(L, 4);
+	// stack is reset
+
+	if (index <= 0 || index > mmap_info_arr->size) {
+		lua_pushnil(L);
+	} else {
+		mmap_info = mmap_info_arr->values[index - 1];
+		lua_newuserdata(L, sizeof(struct lua_mmap_info));
+
+		// stores mmap_info (light user data) in a table as user value
+		// mmap_info_full_ud.userdata["MMAP_INFO"] = mmap_info_light_ud
+		lua_newtable(L);
+		lua_pushstring(L, MMAP_INFO);
+		lua_pushlightuserdata(L, mmap_info);
+		lua_settable(L, -3);
+
+		lua_setuservalue(L, -2);
+
+		// create metatable and set some metamethods
+		luaL_newmetatable(L, MMAP_INFO_METATABLE);
+
+		lua_pushstring(L, "__index");
+		lua_pushcfunction(L, mmap_info_index);
+		lua_settable(L, -3);
+
+		// sanity checks
+		ASSERT(lua_istable(L, -1), "");
+		ASSERT(lua_isuserdata(L, -2), "");
+
+		// set metatable of process context
+		lua_setmetatable(L, -2);
+
+		// make sure that we return mmap_info user data
+		ASSERT(lua_isuserdata(L, -1),
+		       "mmap_info_arr_index: stack[-1] not userdata");
+	}
+
+	return 1;
+}
+
+/**
+ * @brief Get the mmap_info array length
+ * Expects the mmap_info_array userdata on the top of the stack
+ * Stack: [-1, +1]
+ * 
+ * @param L The lua state
+ * @return Number of return values (1)
+ */
+int mmap_info_arr_len(lua_State *L)
+{
+	struct lua_mmap_info_array *mmap_info_arr;
+
+	ASSERT(lua_isuserdata(L, -1),
+	       "mmap_info_arr_len: stack[-2] not userdata");
+
+	// get mmap_info_arr_full_ud.userdata["MMAP_INFO_ARR"]
+	// which is the light ud
+	lua_getuservalue(L, -1);
+	ASSERT(lua_istable(L, -1), "mmap_info_arr_len: stack[-1] not table");
+	lua_pushstring(L, MMAP_INFO_ARR);
+	lua_gettable(L, -2);
+
+	mmap_info_arr = (struct lua_mmap_info_array *)lua_touserdata(L, -1);
+	ASSERT(mmap_info_arr != NULL,
+	       "mmap_info_arr_len: mmap_info_arr == NULL");
+
+	lua_pop(L, 3);
+	// stack is reset
+
+	// return the size of the mmap_info_arr
+	lua_pushinteger(L, (lua_Integer)mmap_info_arr->size);
+
+	return 1;
+}
+
+/**
+ * @brief Frees lua_mmap_info
+ * 
+ * @param event_info 
+ */
+void delete_lua_mmap_info(struct lua_mmap_info *mmap_info)
+{
+	if (mmap_info == NULL) {
+		return;
+	}
+
+	if (mmap_info->event_info != NULL) {
+		delete_lua_event_info(mmap_info->event_info);
+	}
+
+	if (mmap_info->file_info != NULL) {
+		delete_lua_file_info(mmap_info->file_info);
+	}
+
+	free(mmap_info);
+	mmap_info = NULL;
+}
+
+/**
+ * @brief Frees lua_mmap_info_array
+ * 
+ * @param event_info 
+ */
+void delete_lua_mmap_info_array(struct lua_mmap_info_array *arr)
+{
+	if (arr == NULL) {
+		return;
+	}
+
+	if (arr->size > 0) {
+		for (int i = 0; i < arr->size; i++) {
+			delete_lua_mmap_info(arr->values[i]);
+		}
+	}
+
+	arr->size = 0;
+	free(arr->values);
+	arr->values = NULL;
+
+	free(arr);
+	arr = NULL;
+}
+
+/**
+ * @brief Get the mmap info object, initialize it, populate data from db.
+ * Stack: [-1, +1]
+ * 
+ * @param L The lua state.
+ */
+void get_mmap_info(lua_State *L)
+{
+	struct lua_process_context *process_context;
+	struct lua_mmap_info_array *mmap_info_arr;
+	struct lua_db *db;
+
+	process_context = (struct lua_process_context *)lua_touserdata(L, -1);
+	if (process_context == NULL) {
+		fprintf(stderr, "get_mmap_info: process_context == NULL\n");
+		lua_pop(L, 1);
+		lua_pushnil(L);
+		return;
+	}
+
+	if (process_context->mmap_info_arr != NULL) {
+		mmap_info_arr = process_context->mmap_info_arr;
+	} else {
+		mmap_info_arr = (struct lua_mmap_info_array *)malloc(
+			sizeof(struct lua_mmap_info_array));
+		mmap_info_arr->max_size = MMAP_INFO_CHUNK_SIZE;
+		mmap_info_arr->size = 0;
+		mmap_info_arr->values = (struct lua_mmap_info **)malloc(
+			sizeof(struct lua_mmap_info *) *
+			(size_t)mmap_info_arr->max_size);
+
+		db = get_lua_db(L);
+
+		select_all_mmap_info(db->db, db->sqlite_stmts, mmap_info_arr,
+				     process_context->pid);
+		process_context->mmap_info_arr = mmap_info_arr;
+	}
+
+	lua_pop(L, 1);
+	// stack is reset
+
+	lua_newuserdata(L, sizeof(struct lua_mmap_info_array));
+
+	// stores mmap_info_arr (light user data) in a table as user value
+	// mmap_info_arr_full_ud.userdata["MMAP_INFO_ARR"] = mmap_info_arr_light_ud
+	lua_newtable(L);
+	lua_pushstring(L, MMAP_INFO_ARR);
+	lua_pushlightuserdata(L, mmap_info_arr);
+	lua_settable(L, -3);
+	lua_setuservalue(L, -2);
+
+	// create metatable and set some metamethods
+	luaL_newmetatable(L, MMAP_INFO_ARR_METATABLE);
+
+	lua_pushstring(L, "__index");
+	lua_pushcfunction(L, mmap_info_arr_index);
+	lua_settable(L, -3);
+
+	lua_pushstring(L, "__len");
+	lua_pushcfunction(L, mmap_info_arr_len);
+	lua_settable(L, -3);
+
+	// sanity checks
+	ASSERT(lua_istable(L, -1), "");
+	ASSERT(lua_isuserdata(L, -2), "");
+
+	lua_setmetatable(L, -2);
+
+	// make sure we return the mmap_info_arr
+	ASSERT(lua_isuserdata(L, -1), "");
+}

--- a/kalbur/rule_engine/lua/lua_mmap_info.h
+++ b/kalbur/rule_engine/lua/lua_mmap_info.h
@@ -10,10 +10,16 @@
 #define MMAP_INFO "MmapInfo"
 
 #define VM_BASE "vm_base"
+#define VM_FLAGS "vm_flags"
+#define VM_PROT "vm_prot"
+#define VM_LEN "vm_len"
 #define FILE "file"
 struct lua_mmap_info {
 	struct lua_event_info *event_info;
 	u64_t vm_base;
+	u64_t vm_flags;
+	u64_t vm_prot;
+	u64_t vm_len;
 	struct lua_file_info *file_info;
 };
 

--- a/kalbur/rule_engine/lua/lua_mmap_info.h
+++ b/kalbur/rule_engine/lua/lua_mmap_info.h
@@ -1,0 +1,35 @@
+#ifndef LUA_MMAP_INFO_H
+#define LUA_MMAP_INFO_H
+
+#include <lua_process.h>
+
+#define MMAP_INFO_CHUNK_SIZE 100
+#define MMAP_INFO_ARR_METATABLE "MmapInfoArrMetaTable"
+#define MMAP_INFO_METATABLE "MmapInfoMetaTable"
+#define MMAP_INFO_ARR "MmapInfoArr"
+#define MMAP_INFO "MmapInfo"
+
+#define VM_BASE "vm_base"
+#define FILE "file"
+struct lua_mmap_info {
+	struct lua_event_info *event_info;
+	u64_t vm_base;
+	struct lua_file_info *file_info;
+};
+
+typedef struct lua_mmap_info_array {
+	int max_size;
+	int size;
+	struct lua_mmap_info **values;
+} lua_mmap_info_array;
+
+void delete_lua_mmap_info(struct lua_mmap_info *mmap_info);
+void delete_lua_mmap_info_array(struct lua_mmap_info_array *arr);
+
+int mmap_info_index(lua_State *L);
+int mmap_info_arr_index(lua_State *L);
+int mmap_info_arr_len(lua_State *L);
+
+void get_mmap_info(lua_State *L);
+
+#endif // LUA_MMAP_INFO_H

--- a/kalbur/rule_engine/lua/lua_modprobe_overwrite_info.c
+++ b/kalbur/rule_engine/lua/lua_modprobe_overwrite_info.c
@@ -1,0 +1,332 @@
+#include "lua_modprobe_overwrite_info.h"
+
+/**
+ * @brief Frees lua_modprobe_overwrite_info
+ * 
+ * @param event_info 
+ */
+void delete_lua_modprobe_overwrite_info(
+	struct lua_modprobe_overwrite_info *modprobe_overwrite_info)
+{
+	if (modprobe_overwrite_info == NULL) {
+		return;
+	}
+
+	if (modprobe_overwrite_info->event_info != NULL) {
+		delete_lua_event_info(modprobe_overwrite_info->event_info);
+	}
+
+	if (modprobe_overwrite_info->new_modprobe_path != NULL) {
+		free(modprobe_overwrite_info->new_modprobe_path);
+		modprobe_overwrite_info->new_modprobe_path = NULL;
+	}
+
+	free(modprobe_overwrite_info);
+	modprobe_overwrite_info = NULL;
+}
+
+/**
+ * @brief Frees lua_modprobe_overwrite_info_array
+ * 
+ * @param event_info 
+ */
+void delete_lua_modprobe_overwrite_info_array(
+	struct lua_modprobe_overwrite_info_array *arr)
+{
+	if (arr == NULL) {
+		return;
+	}
+
+	if (arr->size > 0) {
+		for (int i = 0; i < arr->size; i++) {
+			delete_lua_modprobe_overwrite_info(arr->values[i]);
+		}
+	}
+
+	arr->size = 0;
+	free(arr->values);
+	arr->values = NULL;
+
+	free(arr);
+	arr = NULL;
+}
+
+/**
+ * @brief handle index access of modprobe_overwrite_info
+ * Expects stack to have string attribute at the top
+ * and modprobe_overwrite_info user data at position -2.
+ * returns nil if error occurs.
+ * 
+ * Stack: [-2, +1]
+ * @param L
+ * @return number of return values (1)
+ */
+int modprobe_overwrite_info_index(lua_State *L)
+{
+	struct lua_modprobe_overwrite_info *modprobe_overwrite_info;
+	const char *attribute;
+
+	ASSERT(lua_isuserdata(L, -2),
+	       "modprobe_overwrite_info_index: stack[-2] not userdata");
+
+	// make sure that the attribute is string
+	if (!lua_isstring(L, -1)) {
+		fprintf(stderr,
+			"modprobe_overwrite_info_index: stack[-1] not string\n");
+		lua_pop(L, 2);
+		lua_pushnil(L);
+		return 1;
+	}
+
+	// get modprobe_overwrite_info light user data
+	lua_getuservalue(L, -2);
+	lua_pushstring(L, MODPROBE_OVERWRITE_INFO);
+	lua_gettable(L, -2);
+	ASSERT(lua_isuserdata(L, -1),
+	       "modprobe_overwrite_info_index: modprobe_overwrite_info user value not found");
+
+	modprobe_overwrite_info =
+		(struct lua_modprobe_overwrite_info *)lua_touserdata(L, -1);
+	ASSERT(modprobe_overwrite_info != NULL,
+	       "modprobe_overwrite_info_index: modprobe_overwrite_info is NULL");
+
+	lua_pop(L, 2);
+
+	// get string attribute
+	attribute = lua_tostring(L, -1);
+
+	// swap attribute and modprobe_overwrite_info user data
+	lua_rotate(L, -2, 1);
+	lua_pop(L, 1);
+
+	// handle attribute
+	if (IS_ATTR(attribute, EVENT_TIME)) {
+		lua_pop(L, 1);
+		lua_pushinteger(L, (lua_Integer)modprobe_overwrite_info
+					   ->event_info->event_time);
+		return 1;
+	} else if (IS_ATTR(attribute, SYSCALL)) {
+		lua_pop(L, 1);
+		lua_pushinteger(L, (lua_Integer)modprobe_overwrite_info
+					   ->event_info->syscall);
+		return 1;
+	} else if (IS_ATTR(attribute, PROCESS_NAME)) {
+		lua_pop(L, 1);
+		lua_pushstring(
+			L, modprobe_overwrite_info->event_info->process_name);
+		return 1;
+	} else if (IS_ATTR(attribute, NEW_MODPROBE_PATH_ATTR)) {
+		lua_pop(L, 1);
+		lua_pushinteger(L, (lua_Integer)modprobe_overwrite_info
+					   ->new_modprobe_path);
+		return 1;
+	} else {
+		fprintf(stderr,
+			"modprobe_overwrite_info_index: invalid attribute: %s\n",
+			attribute);
+		lua_pop(L, 1);
+		lua_pushnil(L);
+		return 1;
+	}
+}
+
+/**
+ * @brief handle index access of modprobe_overwrite_info_arr
+ * Expects stack to have integer attribute at the top
+ * and proces_context user data at position -2.
+ * returns nil if error occurs.
+ * Stack: [-2, +1]
+ * 
+ * @param L 
+ * @return Number of return values (1)
+ */
+int modprobe_overwrite_info_arr_index(lua_State *L)
+{
+	struct lua_modprobe_overwrite_info_array *modprobe_overwrite_info_arr;
+	struct lua_modprobe_overwrite_info *modprobe_overwrite_info;
+	int index;
+
+	if (!lua_isinteger(L, -1)) {
+		fprintf(stderr,
+			"modprobe_overwrite_info_arr_index: stack[-1] not integer\n");
+		lua_pop(L, 2);
+		lua_pushnil(L);
+		return 1;
+	}
+
+	// get the integer index
+	index = (int)lua_tointeger(L, -1);
+	ASSERT(lua_isuserdata(L, -2),
+	       "modprobe_overwrite_info_arr_index: stack[-2] not userdata");
+
+	// get modprobe_overwrite_info_arr_full_ud.userdata["MODPROBE_OVERWRITE_INFO_ARR"]
+	// which is the light ud
+	lua_getuservalue(L, -2);
+	ASSERT(lua_istable(L, -1),
+	       "modprobe_overwrite_info_arr_index: stack[-1] not table");
+	lua_pushstring(L, MODPROBE_OVERWRITE_INFO_ARR);
+	lua_gettable(L, -2);
+
+	modprobe_overwrite_info_arr =
+		(struct lua_modprobe_overwrite_info_array *)lua_touserdata(L,
+									   -1);
+	ASSERT(modprobe_overwrite_info_arr != NULL,
+	       "modprobe_overwrite_info_arr_index: modprobe_overwrite_info_arr == NULL");
+
+	lua_pop(L, 4);
+	// stack is reset
+
+	if (index <= 0 || index > modprobe_overwrite_info_arr->size) {
+		lua_pushnil(L);
+	} else {
+		modprobe_overwrite_info =
+			modprobe_overwrite_info_arr->values[index - 1];
+		lua_newuserdata(L, sizeof(struct lua_modprobe_overwrite_info));
+
+		// stores modprobe_overwrite_info (light user data) in a table as user value
+		// modprobe_overwrite_info_full_ud.userdata["MODPROBE_OVERWRITE_INFO"] = modprobe_overwrite_info_light_ud
+		lua_newtable(L);
+		lua_pushstring(L, MODPROBE_OVERWRITE_INFO);
+		lua_pushlightuserdata(L, modprobe_overwrite_info);
+		lua_settable(L, -3);
+
+		lua_setuservalue(L, -2);
+
+		// create metatable and set some metamethods
+		luaL_newmetatable(L, MODPROBE_OVERWRITE_INFO_METATABLE);
+
+		lua_pushstring(L, "__index");
+		lua_pushcfunction(L, modprobe_overwrite_info_index);
+		lua_settable(L, -3);
+
+		// sanity checks
+		ASSERT(lua_istable(L, -1), "");
+		ASSERT(lua_isuserdata(L, -2), "");
+
+		// set metatable of process context
+		lua_setmetatable(L, -2);
+
+		// make sure that we return modprobe_overwrite_info user data
+		ASSERT(lua_isuserdata(L, -1),
+		       "modprobe_overwrite_info_arr_index: stack[-1] not userdata");
+	}
+
+	return 1;
+}
+
+/**
+ * @brief Get the modprobe_overwrite_info array length
+ * Expects the modprobe_overwrite_info_array userdata on the top of the stack
+ * Stack: [-1, +1]
+ * 
+ * @param L The lua state
+ * @return Number of return values (1)
+ */
+int modprobe_overwrite_info_arr_len(lua_State *L)
+{
+	struct lua_modprobe_overwrite_info_array *modprobe_overwrite_info_arr;
+
+	ASSERT(lua_isuserdata(L, -1),
+	       "modprobe_overwrite_info_arr_len: stack[-2] not userdata");
+
+	// get modprobe_overwrite_info_arr_full_ud.userdata["MODPROBE_OVERWRITE_INFO_ARR"]
+	// which is the light ud
+	lua_getuservalue(L, -1);
+	ASSERT(lua_istable(L, -1),
+	       "modprobe_overwrite_info_arr_len: stack[-1] not table");
+	lua_pushstring(L, MODPROBE_OVERWRITE_INFO_ARR);
+	lua_gettable(L, -2);
+
+	modprobe_overwrite_info_arr =
+		(struct lua_modprobe_overwrite_info_array *)lua_touserdata(L,
+									   -1);
+	ASSERT(modprobe_overwrite_info_arr != NULL,
+	       "modprobe_overwrite_info_arr_len: modprobe_overwrite_info_arr == NULL");
+
+	lua_pop(L, 3);
+	// stack is reset
+
+	// return the size of the modprobe_overwrite_info_arr
+	lua_pushinteger(L, (lua_Integer)modprobe_overwrite_info_arr->size);
+
+	return 1;
+}
+
+/**
+ * @brief Get the modprobe_overwrite_info object, initialize it, populate data from db.
+ * Stack: [-1, +1]
+ * 
+ * @param L The lua state.
+ */
+void get_modprobe_overwrite_info(lua_State *L)
+{
+	struct lua_process_context *process_context;
+	struct lua_modprobe_overwrite_info_array *modprobe_overwrite_info_arr;
+	struct lua_db *db;
+
+	process_context = (struct lua_process_context *)lua_touserdata(L, -1);
+	if (process_context == NULL) {
+		fprintf(stderr,
+			"get_modprobe_overwrite_info: process_context == NULL\n");
+		lua_pop(L, 1);
+		lua_pushnil(L);
+		return;
+	}
+
+	if (process_context->modprobe_overwrite_info_arr != NULL) {
+		modprobe_overwrite_info_arr =
+			process_context->modprobe_overwrite_info_arr;
+	} else {
+		modprobe_overwrite_info_arr =
+			(struct lua_modprobe_overwrite_info_array *)malloc(
+				sizeof(struct lua_modprobe_overwrite_info_array));
+		modprobe_overwrite_info_arr->max_size =
+			MODPROBE_OVERWRITE_INFO_CHUNK_SIZE;
+		modprobe_overwrite_info_arr->size = 0;
+		modprobe_overwrite_info_arr->values =
+			(struct lua_modprobe_overwrite_info **)malloc(
+				sizeof(struct lua_modprobe_overwrite_info *) *
+				(size_t)modprobe_overwrite_info_arr->max_size);
+
+		db = get_lua_db(L);
+
+		select_all_modprobe_overwrite_info(db->db, db->sqlite_stmts,
+						   modprobe_overwrite_info_arr,
+						   process_context->pid);
+		process_context->modprobe_overwrite_info_arr =
+			modprobe_overwrite_info_arr;
+	}
+
+	lua_pop(L, 1);
+	// stack is reset
+
+	lua_newuserdata(L, sizeof(struct lua_modprobe_overwrite_info_array));
+
+	// stores modprobe_overwrite_info_arr (light user data) in a table as user value
+	// modprobe_overwrite_info_arr_full_ud.userdata["MODPROBE_OVERWRITE_INFO_ARR"] = modprobe_overwrite_info_arr_light_ud
+	lua_newtable(L);
+	lua_pushstring(L, MODPROBE_OVERWRITE_INFO_ARR);
+	lua_pushlightuserdata(L, modprobe_overwrite_info_arr);
+	lua_settable(L, -3);
+	lua_setuservalue(L, -2);
+
+	// create metatable and set some metamethods
+	luaL_newmetatable(L, MODPROBE_OVERWRITE_INFO_ARR_METATABLE);
+
+	lua_pushstring(L, "__index");
+	lua_pushcfunction(L, modprobe_overwrite_info_arr_index);
+	lua_settable(L, -3);
+
+	lua_pushstring(L, "__len");
+	lua_pushcfunction(L, modprobe_overwrite_info_arr_len);
+	lua_settable(L, -3);
+
+	// sanity checks
+	ASSERT(lua_istable(L, -1), "");
+	ASSERT(lua_isuserdata(L, -2), "");
+
+	lua_setmetatable(L, -2);
+
+	// make sure we return the modprobe_overwrite_info_arr
+	ASSERT(lua_isuserdata(L, -1), "");
+}

--- a/kalbur/rule_engine/lua/lua_modprobe_overwrite_info.c
+++ b/kalbur/rule_engine/lua/lua_modprobe_overwrite_info.c
@@ -117,8 +117,7 @@ int modprobe_overwrite_info_index(lua_State *L)
 		return 1;
 	} else if (IS_ATTR(attribute, NEW_MODPROBE_PATH_ATTR)) {
 		lua_pop(L, 1);
-		lua_pushinteger(L, (lua_Integer)modprobe_overwrite_info
-					   ->new_modprobe_path);
+		lua_pushstring(L, modprobe_overwrite_info->new_modprobe_path);
 		return 1;
 	} else {
 		fprintf(stderr,

--- a/kalbur/rule_engine/lua/lua_modprobe_overwrite_info.h
+++ b/kalbur/rule_engine/lua/lua_modprobe_overwrite_info.h
@@ -1,0 +1,36 @@
+#ifndef LUA_MODPROBE_OVERWRITE_INFO_H
+#define LUA_MODPROBE_OVERWRITE_INFO_H
+
+#include <lua_process.h>
+
+#define MODPROBE_OVERWRITE_INFO_CHUNK_SIZE 100
+#define MODPROBE_OVERWRITE_INFO_ARR_METATABLE                                  \
+	"ModprobeOverwriteInfoArrMetaTable"
+#define MODPROBE_OVERWRITE_INFO_METATABLE "ModprobeOverwriteInfoMetaTable"
+#define MODPROBE_OVERWRITE_INFO_ARR "ModprobeOverwriteInfoArr"
+#define MODPROBE_OVERWRITE_INFO "ModprobeOverwriteInfo"
+
+#define NEW_MODPROBE_PATH_ATTR "new_modprobe_path"
+struct lua_modprobe_overwrite_info {
+	struct lua_event_info *event_info;
+	char *new_modprobe_path;
+};
+
+typedef struct lua_modprobe_overwrite_info_array {
+	int max_size;
+	int size;
+	struct lua_modprobe_overwrite_info **values;
+} lua_modprobe_overwrite_info_array;
+
+void delete_lua_modprobe_overwrite_info(
+	struct lua_modprobe_overwrite_info *modprobe_overwrite_info);
+void delete_lua_modprobe_overwrite_info_array(
+	struct lua_modprobe_overwrite_info_array *arr);
+
+int modprobe_overwrite_info_index(lua_State *L);
+int modprobe_overwrite_info_arr_index(lua_State *L);
+int modprobe_overwrite_info_arr_len(lua_State *L);
+
+void get_modprobe_overwrite_info(lua_State *L);
+
+#endif // LUA_MODPROBE_OVERWRITE_INFO_H

--- a/kalbur/rule_engine/lua/lua_module_load_info.c
+++ b/kalbur/rule_engine/lua/lua_module_load_info.c
@@ -1,0 +1,350 @@
+#include "lua_module_load_info.h"
+
+/**
+ * @brief handle index access of module_load_info
+ * Expects stack to have string attribute at the top
+ * and module_load_info user data at position -2.
+ * returns nil if error occurs.
+ * 
+ * Stack: [-2, +1]
+ * @param L
+ * @return number of return values (1)
+ */
+int module_load_info_index(lua_State *L)
+{
+	struct lua_module_load_info *module_load_info;
+	const char *attribute;
+
+	ASSERT(lua_isuserdata(L, -2),
+	       "module_load_info_index: stack[-2] not userdata");
+
+	// make sure that the attribute is string
+	if (!lua_isstring(L, -1)) {
+		fprintf(stderr,
+			"module_load_info_index: stack[-1] not string\n");
+		lua_pop(L, 2);
+		lua_pushnil(L);
+		return 1;
+	}
+
+	// get module_load_info light user data
+	lua_getuservalue(L, -2);
+	lua_pushstring(L, MODULE_LOAD_INFO);
+	lua_gettable(L, -2);
+	ASSERT(lua_isuserdata(L, -1),
+	       "module_load_info_index: module_load_info user value not found");
+
+	module_load_info = (struct lua_module_load_info *)lua_touserdata(L, -1);
+	ASSERT(module_load_info != NULL,
+	       "module_load_info_index: module_load_info is NULL");
+
+	lua_pop(L, 2);
+
+	// get string attribute
+	attribute = lua_tostring(L, -1);
+
+	// swap attribute and module_load_info user data
+	lua_rotate(L, -2, 1);
+	lua_pop(L, 1);
+
+	// handle attribute
+	if (IS_ATTR(attribute, EVENT_TIME)) {
+		lua_pop(L, 1);
+		lua_pushinteger(
+			L,
+			(lua_Integer)module_load_info->event_info->event_time);
+		return 1;
+	} else if (IS_ATTR(attribute, SYSCALL)) {
+		lua_pop(L, 1);
+		lua_pushinteger(
+			L, (lua_Integer)module_load_info->event_info->syscall);
+		return 1;
+	} else if (IS_ATTR(attribute, PROCESS_NAME)) {
+		lua_pop(L, 1);
+		lua_pushstring(L, module_load_info->event_info->process_name);
+		return 1;
+	} else if (IS_ATTR(attribute, FILE)) {
+		lua_pop(L, 1);
+		// stack is reset
+
+		lua_newuserdata(L, sizeof(struct lua_file_info));
+
+		// stores file_info (light user data) in a table as user value
+		// file_info_full_ud.userdata["FILE_INFO"] = file_info_light_ud
+		lua_newtable(L);
+		lua_pushstring(L, FILE_INFO);
+		lua_pushlightuserdata(L, module_load_info->file_info);
+		lua_settable(L, -3);
+
+		lua_setuservalue(L, -2);
+
+		// create new metatable and set its metamethods
+		luaL_newmetatable(L, FILE_INFO_METATABLE);
+
+		lua_pushstring(L, "__index");
+		lua_pushcfunction(L, file_info_index);
+		lua_settable(L, -3);
+
+		// sanity checks
+		ASSERT(lua_istable(L, -1), "");
+		ASSERT(lua_isuserdata(L, -2), "");
+
+		// set metatable of process context
+		lua_setmetatable(L, -2);
+
+		// make sure that we return file_info userdata
+		ASSERT(lua_isuserdata(L, -1), "");
+
+		return 1;
+	} else {
+		fprintf(stderr,
+			"module_load_info_index: invalid attribute: %s\n",
+			attribute);
+		lua_pop(L, 1);
+		lua_pushnil(L);
+		return 1;
+	}
+}
+
+/**
+ * @brief handle index access of module_load_info_arr
+ * Expects stack to have integer attribute at the top
+ * and proces_context user data at position -2.
+ * returns nil if error occurs.
+ * Stack: [-2, +1]
+ * 
+ * @param L 
+ * @return Number of return values (1)
+ */
+int module_load_info_arr_index(lua_State *L)
+{
+	struct lua_module_load_info_array *module_load_info_arr;
+	struct lua_module_load_info *module_load_info;
+	int index;
+
+	if (!lua_isinteger(L, -1)) {
+		fprintf(stderr,
+			"module_load_info_arr_index: stack[-1] not integer\n");
+		lua_pop(L, 2);
+		lua_pushnil(L);
+		return 1;
+	}
+
+	// get the integer index
+	index = (int)lua_tointeger(L, -1);
+	ASSERT(lua_isuserdata(L, -2),
+	       "module_load_info_arr_index: stack[-2] not userdata");
+
+	// get module_load_info_arr_full_ud.userdata["MODULE_LOAD_INFO_ARR"]
+	// which is the light ud
+	lua_getuservalue(L, -2);
+	ASSERT(lua_istable(L, -1),
+	       "module_load_info_arr_index: stack[-1] not table");
+	lua_pushstring(L, MODULE_LOAD_INFO_ARR);
+	lua_gettable(L, -2);
+
+	module_load_info_arr =
+		(struct lua_module_load_info_array *)lua_touserdata(L, -1);
+	ASSERT(module_load_info_arr != NULL,
+	       "module_load_info_arr_index: module_load_info_arr == NULL");
+
+	lua_pop(L, 4);
+	// stack is reset
+
+	if (index <= 0 || index > module_load_info_arr->size) {
+		lua_pushnil(L);
+	} else {
+		module_load_info = module_load_info_arr->values[index - 1];
+		lua_newuserdata(L, sizeof(struct lua_module_load_info));
+
+		// stores module_load_info (light user data) in a table as user value
+		// module_load_info_full_ud.userdata["MODULE_LOAD_INFO"] = module_load_info_light_ud
+		lua_newtable(L);
+		lua_pushstring(L, MODULE_LOAD_INFO);
+		lua_pushlightuserdata(L, module_load_info);
+		lua_settable(L, -3);
+
+		lua_setuservalue(L, -2);
+
+		// create metatable and set some metamethods
+		luaL_newmetatable(L, MODULE_LOAD_INFO_METATABLE);
+
+		lua_pushstring(L, "__index");
+		lua_pushcfunction(L, module_load_info_index);
+		lua_settable(L, -3);
+
+		// sanity checks
+		ASSERT(lua_istable(L, -1), "");
+		ASSERT(lua_isuserdata(L, -2), "");
+
+		// set metatable of process context
+		lua_setmetatable(L, -2);
+
+		// make sure that we return module_load_info user data
+		ASSERT(lua_isuserdata(L, -1),
+		       "module_load_info_arr_index: stack[-1] not userdata");
+	}
+
+	return 1;
+}
+
+/**
+ * @brief Get the module_load_info array length
+ * Expects the module_load_info_array userdata on the top of the stack
+ * Stack: [-1, +1]
+ * 
+ * @param L The lua state
+ * @return Number of return values (1)
+ */
+int module_load_info_arr_len(lua_State *L)
+{
+	struct lua_module_load_info_array *module_load_info_arr;
+
+	ASSERT(lua_isuserdata(L, -1),
+	       "module_load_info_arr_len: stack[-2] not userdata");
+
+	// get module_load_info_arr_full_ud.userdata["MODULE_LOAD_INFO_ARR"]
+	// which is the light ud
+	lua_getuservalue(L, -1);
+	ASSERT(lua_istable(L, -1),
+	       "module_load_info_arr_len: stack[-1] not table");
+	lua_pushstring(L, MODULE_LOAD_INFO_ARR);
+	lua_gettable(L, -2);
+
+	module_load_info_arr =
+		(struct lua_module_load_info_array *)lua_touserdata(L, -1);
+	ASSERT(module_load_info_arr != NULL,
+	       "module_load_info_arr_len: module_load_info_arr == NULL");
+
+	lua_pop(L, 3);
+	// stack is reset
+
+	// return the size of the module_load_info_arr
+	lua_pushinteger(L, (lua_Integer)module_load_info_arr->size);
+
+	return 1;
+}
+
+/**
+ * @brief Frees lua_module_load_info
+ * 
+ * @param event_info 
+ */
+void delete_lua_module_load_info(struct lua_module_load_info *module_load_info)
+{
+	if (module_load_info == NULL) {
+		return;
+	}
+
+	if (module_load_info->event_info != NULL) {
+		delete_lua_event_info(module_load_info->event_info);
+	}
+
+	if (module_load_info->file_info != NULL) {
+		delete_lua_file_info(module_load_info->file_info);
+	}
+
+	free(module_load_info);
+	module_load_info = NULL;
+}
+
+/**
+ * @brief Frees lua_module_load_info_array
+ * 
+ * @param event_info 
+ */
+void delete_lua_module_load_info_array(struct lua_module_load_info_array *arr)
+{
+	if (arr == NULL) {
+		return;
+	}
+
+	if (arr->size > 0) {
+		for (int i = 0; i < arr->size; i++) {
+			delete_lua_module_load_info(arr->values[i]);
+		}
+	}
+
+	arr->size = 0;
+	free(arr->values);
+	arr->values = NULL;
+
+	free(arr);
+	arr = NULL;
+}
+
+/**
+ * @brief Get the module_load info object, initialize it, populate data from db.
+ * Stack: [-1, +1]
+ * 
+ * @param L The lua state.
+ */
+void get_module_load_info(lua_State *L)
+{
+	struct lua_process_context *process_context;
+	struct lua_module_load_info_array *module_load_info_arr;
+	struct lua_db *db;
+
+	process_context = (struct lua_process_context *)lua_touserdata(L, -1);
+	if (process_context == NULL) {
+		fprintf(stderr,
+			"get_module_load_info: process_context == NULL\n");
+		lua_pop(L, 1);
+		lua_pushnil(L);
+		return;
+	}
+
+	if (process_context->module_load_info_arr != NULL) {
+		module_load_info_arr = process_context->module_load_info_arr;
+	} else {
+		module_load_info_arr =
+			(struct lua_module_load_info_array *)malloc(
+				sizeof(struct lua_module_load_info_array));
+		module_load_info_arr->max_size = MODULE_LOAD_INFO_CHUNK_SIZE;
+		module_load_info_arr->size = 0;
+		module_load_info_arr->values =
+			(struct lua_module_load_info **)malloc(
+				sizeof(struct lua_module_load_info *) *
+				(size_t)module_load_info_arr->max_size);
+
+		db = get_lua_db(L);
+
+		select_all_module_load_info(db->db, db->sqlite_stmts,
+					    module_load_info_arr,
+					    process_context->pid);
+		process_context->module_load_info_arr = module_load_info_arr;
+	}
+
+	lua_pop(L, 1);
+	// stack is reset
+
+	lua_newuserdata(L, sizeof(struct lua_module_load_info_array));
+
+	// stores module_load_info_arr (light user data) in a table as user value
+	// module_load_info_arr_full_ud.userdata["MODULE_LOAD_INFO_ARR"] = module_load_info_arr_light_ud
+	lua_newtable(L);
+	lua_pushstring(L, MODULE_LOAD_INFO_ARR);
+	lua_pushlightuserdata(L, module_load_info_arr);
+	lua_settable(L, -3);
+	lua_setuservalue(L, -2);
+
+	// create metatable and set some metamethods
+	luaL_newmetatable(L, MODULE_LOAD_INFO_ARR_METATABLE);
+
+	lua_pushstring(L, "__index");
+	lua_pushcfunction(L, module_load_info_arr_index);
+	lua_settable(L, -3);
+
+	lua_pushstring(L, "__len");
+	lua_pushcfunction(L, module_load_info_arr_len);
+	lua_settable(L, -3);
+
+	// sanity checks
+	ASSERT(lua_istable(L, -1), "");
+	ASSERT(lua_isuserdata(L, -2), "");
+
+	lua_setmetatable(L, -2);
+
+	// make sure we return the module_load_info_arr
+	ASSERT(lua_isuserdata(L, -1), "");
+}

--- a/kalbur/rule_engine/lua/lua_module_load_info.h
+++ b/kalbur/rule_engine/lua/lua_module_load_info.h
@@ -1,0 +1,33 @@
+#ifndef LUA_MODULE_LOAD_INFO_H
+#define LUA_MODULE_LOAD_INFO_H
+
+#include <lua_process.h>
+
+#define MODULE_LOAD_INFO_CHUNK_SIZE 100
+#define MODULE_LOAD_INFO_ARR_METATABLE "ModuleLoadInfoArrMetaTable"
+#define MODULE_LOAD_INFO_METATABLE "ModuleLoadInfoMetaTable"
+#define MODULE_LOAD_INFO_ARR "ModuleLoadInfoArr"
+#define MODULE_LOAD_INFO "ModuleLoadInfo"
+
+#define FILE "file"
+struct lua_module_load_info {
+	struct lua_event_info *event_info;
+	struct lua_file_info *file_info;
+};
+
+typedef struct lua_module_load_info_array {
+	int max_size;
+	int size;
+	struct lua_module_load_info **values;
+} lua_module_load_info_array;
+
+void delete_lua_module_load_info(struct lua_module_load_info *module_load_info);
+void delete_lua_module_load_info_array(struct lua_module_load_info_array *arr);
+
+int module_load_info_index(lua_State *L);
+int module_load_info_arr_index(lua_State *L);
+int module_load_info_arr_len(lua_State *L);
+
+void get_module_load_info(lua_State *L);
+
+#endif // LUA_MODULE_LOAD_INFO_H

--- a/kalbur/rule_engine/lua/lua_process.c
+++ b/kalbur/rule_engine/lua/lua_process.c
@@ -106,6 +106,9 @@ int process_index(lua_State *L)
 	} else if (IS_ATTR(attr, SOCKET_CREATE_INFO)) {
 		lua_pop(L, 1);
 		get_socket_create_info(L);
+	} else if (IS_ATTR(attr, TCP_CONNECTION_INFO)) {
+		lua_pop(L, 1);
+		get_tcp_connection_info(L);
 	} else {
 		fprintf(stderr, "process_index: unknown attribute\n");
 		lua_pop(L, 2);
@@ -189,6 +192,7 @@ int get_process_by_pid(lua_State *L)
 		process_context->mmap_info_arr = NULL;
 		process_context->ptrace_info_arr = NULL;
 		process_context->socket_create_info_arr = NULL;
+		process_context->tcp_connection_info_arr = NULL;
 	}
 
 	// sanity checks
@@ -299,6 +303,8 @@ void teardown_process_context(lua_State *L)
 		delete_lua_ptrace_info_array(process_context->ptrace_info_arr);
 		delete_lua_socket_create_info_array(
 			process_context->socket_create_info_arr);
+		delete_lua_tcp_connection_info_array(
+			process_context->tcp_connection_info_arr);
 
 		lua_pop(L, 1);
 	}

--- a/kalbur/rule_engine/lua/lua_process.c
+++ b/kalbur/rule_engine/lua/lua_process.c
@@ -115,6 +115,9 @@ int process_index(lua_State *L)
 	} else if (IS_ATTR(attr, MODPROBE_OVERWRITE_INFO)) {
 		lua_pop(L, 1);
 		get_modprobe_overwrite_info(L);
+	} else if (IS_ATTR(attr, PROCESS_LPE_INFO)) {
+		lua_pop(L, 1);
+		get_process_lpe_info(L);
 	} else {
 		fprintf(stderr, "process_index: unknown attribute\n");
 		lua_pop(L, 2);
@@ -201,6 +204,7 @@ int get_process_by_pid(lua_State *L)
 		process_context->tcp_connection_info_arr = NULL;
 		process_context->module_load_info_arr = NULL;
 		process_context->modprobe_overwrite_info_arr = NULL;
+		process_context->process_lpe_info_arr = NULL;
 	}
 
 	// sanity checks
@@ -317,6 +321,7 @@ void teardown_process_context(lua_State *L)
 			process_context->module_load_info_arr);
 		delete_lua_modprobe_overwrite_info_array(
 			process_context->modprobe_overwrite_info_arr);
+		delete_lua_process_lpe_info_array(process_context->process_lpe_info_arr);
 
 		lua_pop(L, 1);
 	}

--- a/kalbur/rule_engine/lua/lua_process.c
+++ b/kalbur/rule_engine/lua/lua_process.c
@@ -1,0 +1,297 @@
+#include "lua_process.h"
+
+/**
+ * @brief Get the global lua db object
+ * Stack: [-0, +0]
+ * 
+ * @param L The lua state.
+ *
+ * @return The length of the mmap_info_arr array.
+ */
+struct lua_db *get_lua_db(lua_State *L)
+{
+	struct lua_db *db;
+
+	lua_pushstring(L, GLOBAL_LUA_DB);
+	lua_gettable(L, LUA_REGISTRYINDEX);
+	ASSERT(lua_isuserdata(L, -1), "get_lua_db: global db conn not found");
+
+	db = (struct lua_db *)lua_touserdata(L, -1);
+	ASSERT(db != NULL, "get_lua_db: global db conn not found");
+	lua_pop(L, 1);
+
+	return db;
+}
+
+/**
+ * @brief Get the global pid list object.
+ * Stack: [-0, +1]
+ * 
+ * @param L Lua state
+ * Stack: [-0, +1]
+ */
+void get_global_pid_list(lua_State *L)
+{
+	lua_pushstring(L, GLOBAL_PID_LIST);
+	lua_gettable(L, LUA_REGISTRYINDEX);
+	ASSERT(lua_istable(L, -1), "get_global_pid_list: stack[-1] not table");
+}
+
+/**
+ * @brief Get the global pid object from the pid list.
+ * if pid exists in the list, it returns userdata.
+ * otherwise nil.
+ * Stack: [-0, +1]
+ * 
+ * @param L 
+ * @param pid
+ */
+void get_global_pid(lua_State *L, int pid)
+{
+	// get REGISTRY[GLOBAL_PID_LIST][pid] on top
+	// of the stack
+	get_global_pid_list(L);
+	lua_pushinteger(L, (lua_Integer)pid);
+	lua_gettable(L, -2);
+	lua_rotate(L, -2, 1);
+	lua_pop(L, 1);
+}
+
+/**
+ * @brief handle index access of process_context
+ * Expects stack to have string attribute at the top
+ * and proces_context user data at position -2.
+ * returns nil if error occurs.
+ * 
+ * Stack: [-2, +1]
+ * @param L
+ * @return number of return values (1)
+ */
+int process_index(lua_State *L)
+{
+	struct lua_process_context *process_context;
+	const char *attr;
+
+	// get the process context userdata.
+	process_context = (struct lua_process_context *)lua_touserdata(L, -2);
+	if (process_context == NULL) {
+		fprintf(stderr, "process_index: process_context == NULL\n");
+		lua_pop(L, 2);
+		lua_pushnil(L);
+		return 1;
+	}
+
+	// get the attribute name.
+	attr = lua_tostring(L, -1);
+	if (attr == NULL) {
+		fprintf(stderr, "process_index: attr == NULL\n");
+		lua_pop(L, 2);
+		lua_pushnil(L);
+		return 1;
+	}
+
+	// handle attribute
+	if (IS_ATTR(attr, PID)) {
+		lua_pop(L, 2);
+		lua_pushinteger(L, (lua_Integer)process_context->pid);
+	} else if (IS_ATTR(attr, MMAP_INFO)) {
+		lua_pop(L, 1);
+		get_mmap_info(L);
+	} else {
+		fprintf(stderr, "process_index: unknown attribute\n");
+		lua_pop(L, 2);
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+/**
+ * @brief Get the global pid object from the pid list.
+ * if pid does not exists in the list, it initializes a new pid object.
+ * returns nil on error.
+ * Stack: [-1, +1]
+ * 
+ * @param L 
+ * @param pid
+ * @return number of return values (1)
+ */
+int get_process_by_pid(lua_State *L)
+{
+	int pid;
+	bool pid_already_exists;
+	struct lua_process_context *process_context;
+
+	// git pid argument
+	pid = (int)luaL_checkinteger(L, -1);
+	if (pid == 0) {
+		fprintf(stderr,
+			"get_process_by_pid: invalid arg to get_process_by_pid");
+		lua_pushnil(L);
+	}
+	lua_pop(L, 1);
+	// stack is reset
+
+	get_global_pid(L, pid);
+
+	// check if pid is already in the list
+	if (lua_isnil(L, -1) == 0) {
+		ASSERT(lua_isuserdata(L, -1),
+		       "get_process_by_pid: pid in global pid list not found");
+		pid_already_exists = true;
+	} else {
+		pid_already_exists = false;
+	}
+
+	// if pid already exists, we just get the process context
+	if (pid_already_exists) {
+		process_context =
+			(struct lua_process_context *)lua_touserdata(L, -1);
+		ASSERT(process_context != NULL,
+		       "get_process_by_pid: process context not found");
+		lua_pop(L, 1);
+	} else {
+		// set REGISTRY[GLOBAL_PID_LIST][pid] = process_context
+		lua_pop(L, 1); // remove the nil from the top
+		get_global_pid_list(L);
+		lua_pushinteger(L, (lua_Integer)pid);
+		process_context = (struct lua_process_context *)lua_newuserdata(
+			L, sizeof(struct lua_process_context));
+		if (process_context == NULL) {
+			fprintf(stderr,
+				"get_process_by_pid: could not initialize lua_process_context");
+			lua_pop(L, 3);
+			goto fail;
+		}
+		ASSERT(lua_isuserdata(L, -1),
+		       "get_process_by_pid: process context not found");
+		ASSERT((int)lua_tointeger(L, -2) == pid,
+		       "get_process_by_pid: process context not found");
+		ASSERT(lua_istable(L, -3),
+		       "get_process_by_pid: process context not found");
+		lua_settable(L, -3);
+		lua_pop(L, 1);
+	}
+	// stack is reset
+
+	// initialize process context
+	if (!pid_already_exists) {
+		process_context->pid = pid;
+		process_context->process_info_arr = NULL;
+		process_context->mmap_info_arr = NULL;
+	}
+
+	// sanity checks
+	ASSERT(process_context->pid == pid, "");
+	ASSERT(process_context->mmap_info_arr == NULL, "");
+
+	// get REGISTRY[GLOBAL_PID_LIST][pid]
+	get_global_pid(L, pid);
+	ASSERT(lua_isuserdata(L, -1),
+	       "get_process_by_pid: process context not found");
+
+	// create new metatable to associate with 'Process Context' object
+	luaL_newmetatable(L, PROCESS_METATABLE);
+	lua_pushstring(L, "__index");
+	lua_pushcfunction(L, process_index);
+	lua_settable(L, -3);
+
+	// sanity checks
+	ASSERT(lua_istable(L, -1), "");
+	ASSERT(lua_isuserdata(L, -2), "");
+
+	// set metatable of process context
+	lua_setmetatable(L, -2);
+
+	// make sure we return process_context on top of stack
+	ASSERT(lua_isuserdata(L, -1), "");
+
+	// returns the process context user data.
+	return 1;
+
+fail:
+	// return nil
+	lua_pushnil(L);
+	return 1;
+}
+
+/**
+ * @brief Initializes the process context by setting up lua_db, global
+ * functions, and the global pid list.
+ * 
+ * @param L 
+ */
+void init_process_context(lua_State *L, sqlite3 *db, hashtable_t *sqlite_stmts)
+{
+	struct lua_db *lua_db;
+
+	ASSERT(L != NULL, "init_process_context: L == NULL");
+	ASSERT(db != NULL, "init_process_context: db == NULL");
+	ASSERT(sqlite_stmts != NULL,
+	       "init_process_context: sqlite_stmts == NULL");
+
+	// initialize lua_db globally and put it in registry.
+	lua_pushstring(L, GLOBAL_LUA_DB);
+	lua_db = (struct lua_db *)lua_newuserdata(L, sizeof(struct lua_db));
+	if (lua_db == NULL) {
+		fprintf(stderr,
+			"init_process_context: could not initialize lua_db");
+		lua_pop(L, 1);
+		return;
+	}
+
+	lua_db->db = db;
+	lua_db->sqlite_stmts = sqlite_stmts;
+
+	lua_settable(L, LUA_REGISTRYINDEX);
+
+	// expose global get_process_by_pid function
+	lua_pushcfunction(L, get_process_by_pid);
+	lua_setglobal(L, "get_process_by_pid");
+
+	// expose global pid list to keep reference of all process contexts
+	lua_pushstring(L, GLOBAL_PID_LIST);
+	lua_newtable(L);
+	lua_settable(L, LUA_REGISTRYINDEX);
+}
+
+/**
+ * @brief Tears down the process context by removing all processes from
+ * the global pid list and freeing the relevant memory.
+ * 
+ * @param L 
+ */
+void teardown_process_context(lua_State *L)
+{
+	struct lua_process_context *process_context;
+
+	ASSERT(L != NULL, "teardown_process_context: L == NULL");
+
+	// get REGISTRY[GLOBAL_PID_LIST]
+	lua_pushstring(L, GLOBAL_PID_LIST);
+	lua_gettable(L, LUA_REGISTRYINDEX);
+	ASSERT(lua_istable(L, -1),
+	       "teardown_process_context: global pid list not found");
+
+	// Loop over REGISTRY[GLOBAL_PID_LIST]
+	lua_pushnil(L);
+	while (lua_next(L, -2) != 0) {
+		ASSERT(lua_isuserdata(L, -1),
+		       "teardown_process_context: process context not found");
+		process_context =
+			(struct lua_process_context *)lua_touserdata(L, -1);
+		ASSERT(process_context != NULL,
+		       "teardown_process_context: process context is NULL");
+
+		// delete all lua_*info_arrays
+		delete_lua_process_info_array(
+			process_context->process_info_arr);
+		delete_lua_mmap_info_array(process_context->mmap_info_arr);
+
+		lua_pop(L, 1);
+	}
+
+	// reset the stack
+	lua_settop(L, 0);
+
+	return;
+}

--- a/kalbur/rule_engine/lua/lua_process.c
+++ b/kalbur/rule_engine/lua/lua_process.c
@@ -100,6 +100,9 @@ int process_index(lua_State *L)
 	} else if (IS_ATTR(attr, PROCESS_INFO)) {
 		lua_pop(L, 1);
 		get_process_info(L);
+	} else if (IS_ATTR(attr, PTRACE_INFO)) {
+		lua_pop(L, 1);
+		get_ptrace_info(L);
 	} else {
 		fprintf(stderr, "process_index: unknown attribute\n");
 		lua_pop(L, 2);
@@ -181,11 +184,11 @@ int get_process_by_pid(lua_State *L)
 		process_context->pid = pid;
 		process_context->process_info_arr = NULL;
 		process_context->mmap_info_arr = NULL;
+		process_context->ptrace_info_arr = NULL;
 	}
 
 	// sanity checks
 	ASSERT(process_context->pid == pid, "");
-	ASSERT(process_context->mmap_info_arr == NULL, "");
 
 	// get REGISTRY[GLOBAL_PID_LIST][pid]
 	get_global_pid(L, pid);
@@ -289,6 +292,7 @@ void teardown_process_context(lua_State *L)
 		delete_lua_process_info_array(
 			process_context->process_info_arr);
 		delete_lua_mmap_info_array(process_context->mmap_info_arr);
+		delete_lua_ptrace_info_array(process_context->ptrace_info_arr);
 
 		lua_pop(L, 1);
 	}

--- a/kalbur/rule_engine/lua/lua_process.c
+++ b/kalbur/rule_engine/lua/lua_process.c
@@ -112,6 +112,9 @@ int process_index(lua_State *L)
 	} else if (IS_ATTR(attr, MODULE_LOAD_INFO)) {
 		lua_pop(L, 1);
 		get_module_load_info(L);
+	} else if (IS_ATTR(attr, MODPROBE_OVERWRITE_INFO)) {
+		lua_pop(L, 1);
+		get_modprobe_overwrite_info(L);
 	} else {
 		fprintf(stderr, "process_index: unknown attribute\n");
 		lua_pop(L, 2);
@@ -197,6 +200,7 @@ int get_process_by_pid(lua_State *L)
 		process_context->socket_create_info_arr = NULL;
 		process_context->tcp_connection_info_arr = NULL;
 		process_context->module_load_info_arr = NULL;
+		process_context->modprobe_overwrite_info_arr = NULL;
 	}
 
 	// sanity checks
@@ -311,6 +315,8 @@ void teardown_process_context(lua_State *L)
 			process_context->tcp_connection_info_arr);
 		delete_lua_module_load_info_array(
 			process_context->module_load_info_arr);
+		delete_lua_modprobe_overwrite_info_array(
+			process_context->modprobe_overwrite_info_arr);
 
 		lua_pop(L, 1);
 	}

--- a/kalbur/rule_engine/lua/lua_process.c
+++ b/kalbur/rule_engine/lua/lua_process.c
@@ -97,6 +97,9 @@ int process_index(lua_State *L)
 	} else if (IS_ATTR(attr, MMAP_INFO)) {
 		lua_pop(L, 1);
 		get_mmap_info(L);
+	} else if (IS_ATTR(attr, PROCESS_INFO)) {
+		lua_pop(L, 1);
+		get_process_info(L);
 	} else {
 		fprintf(stderr, "process_index: unknown attribute\n");
 		lua_pop(L, 2);

--- a/kalbur/rule_engine/lua/lua_process.c
+++ b/kalbur/rule_engine/lua/lua_process.c
@@ -6,7 +6,7 @@
  * 
  * @param L The lua state.
  *
- * @return The length of the mmap_info_arr array.
+ * @return A pointer to the lua_db object
  */
 struct lua_db *get_lua_db(lua_State *L)
 {
@@ -109,6 +109,9 @@ int process_index(lua_State *L)
 	} else if (IS_ATTR(attr, TCP_CONNECTION_INFO)) {
 		lua_pop(L, 1);
 		get_tcp_connection_info(L);
+	} else if (IS_ATTR(attr, MODULE_LOAD_INFO)) {
+		lua_pop(L, 1);
+		get_module_load_info(L);
 	} else {
 		fprintf(stderr, "process_index: unknown attribute\n");
 		lua_pop(L, 2);
@@ -193,6 +196,7 @@ int get_process_by_pid(lua_State *L)
 		process_context->ptrace_info_arr = NULL;
 		process_context->socket_create_info_arr = NULL;
 		process_context->tcp_connection_info_arr = NULL;
+		process_context->module_load_info_arr = NULL;
 	}
 
 	// sanity checks
@@ -305,6 +309,8 @@ void teardown_process_context(lua_State *L)
 			process_context->socket_create_info_arr);
 		delete_lua_tcp_connection_info_array(
 			process_context->tcp_connection_info_arr);
+		delete_lua_module_load_info_array(
+			process_context->module_load_info_arr);
 
 		lua_pop(L, 1);
 	}

--- a/kalbur/rule_engine/lua/lua_process.c
+++ b/kalbur/rule_engine/lua/lua_process.c
@@ -103,6 +103,9 @@ int process_index(lua_State *L)
 	} else if (IS_ATTR(attr, PTRACE_INFO)) {
 		lua_pop(L, 1);
 		get_ptrace_info(L);
+	} else if (IS_ATTR(attr, SOCKET_CREATE_INFO)) {
+		lua_pop(L, 1);
+		get_socket_create_info(L);
 	} else {
 		fprintf(stderr, "process_index: unknown attribute\n");
 		lua_pop(L, 2);
@@ -185,6 +188,7 @@ int get_process_by_pid(lua_State *L)
 		process_context->process_info_arr = NULL;
 		process_context->mmap_info_arr = NULL;
 		process_context->ptrace_info_arr = NULL;
+		process_context->socket_create_info_arr = NULL;
 	}
 
 	// sanity checks
@@ -293,6 +297,8 @@ void teardown_process_context(lua_State *L)
 			process_context->process_info_arr);
 		delete_lua_mmap_info_array(process_context->mmap_info_arr);
 		delete_lua_ptrace_info_array(process_context->ptrace_info_arr);
+		delete_lua_socket_create_info_array(
+			process_context->socket_create_info_arr);
 
 		lua_pop(L, 1);
 	}

--- a/kalbur/rule_engine/lua/lua_process.h
+++ b/kalbur/rule_engine/lua/lua_process.h
@@ -18,6 +18,7 @@
 #include "lua_socket_create_info.h"
 #include "lua_tcp_connection_info.h"
 #include "lua_module_load_info.h"
+#include "lua_modprobe_overwrite_info.h"
 
 #define GLOBAL_LUA_DB "SENSOR_DB"
 #define GLOBAL_PID_LIST "SENSOR_PID_LIST"
@@ -41,6 +42,7 @@ struct lua_process_context {
 	struct lua_socket_create_info_array *socket_create_info_arr;
 	struct lua_tcp_connection_info_array *tcp_connection_info_arr;
 	struct lua_module_load_info_array *module_load_info_arr;
+	struct lua_modprobe_overwrite_info_array *modprobe_overwrite_info_arr;
 };
 
 struct lua_db *get_lua_db(lua_State *L);

--- a/kalbur/rule_engine/lua/lua_process.h
+++ b/kalbur/rule_engine/lua/lua_process.h
@@ -16,6 +16,7 @@
 #include "lua_mmap_info.h"
 #include "lua_ptrace_info.h"
 #include "lua_socket_create_info.h"
+#include "lua_tcp_connection_info.h"
 
 #define GLOBAL_LUA_DB "SENSOR_DB"
 #define GLOBAL_PID_LIST "SENSOR_PID_LIST"
@@ -37,6 +38,7 @@ struct lua_process_context {
 	struct lua_mmap_info_array *mmap_info_arr;
 	struct lua_ptrace_info_array *ptrace_info_arr;
 	struct lua_socket_create_info_array *socket_create_info_arr;
+	struct lua_tcp_connection_info_array *tcp_connection_info_arr;
 };
 
 struct lua_db *get_lua_db(lua_State *L);

--- a/kalbur/rule_engine/lua/lua_process.h
+++ b/kalbur/rule_engine/lua/lua_process.h
@@ -14,6 +14,7 @@
 #include "lua_file_info.h"
 #include "lua_process_info.h"
 #include "lua_mmap_info.h"
+#include "lua_ptrace_info.h"
 
 #define GLOBAL_LUA_DB "SENSOR_DB"
 #define GLOBAL_PID_LIST "SENSOR_PID_LIST"
@@ -33,6 +34,7 @@ struct lua_process_context {
 	int pid;
 	struct lua_process_info_array *process_info_arr;
 	struct lua_mmap_info_array *mmap_info_arr;
+	struct lua_ptrace_info_array *ptrace_info_arr;
 };
 
 struct lua_db *get_lua_db(lua_State *L);

--- a/kalbur/rule_engine/lua/lua_process.h
+++ b/kalbur/rule_engine/lua/lua_process.h
@@ -1,0 +1,47 @@
+#ifndef LUA_PROCESS_H
+#define LUA_PROCESS_H
+
+#include <string.h>
+#include <stdlib.h>
+#include <lua.h>
+#include <lauxlib.h>
+#include <hash.h>
+#include <sqlite3.h>
+
+#include "err.h"
+#include "database.h"
+#include "lua_event_info.h"
+#include "lua_file_info.h"
+#include "lua_process_info.h"
+#include "lua_mmap_info.h"
+
+#define GLOBAL_LUA_DB "SENSOR_DB"
+#define GLOBAL_PID_LIST "SENSOR_PID_LIST"
+
+#define IS_ATTR(attr_name, attr) strncmp(attr_name, attr, sizeof(attr)) == 0
+
+// TODO: check which process is live with the event_time and exit event.
+
+struct lua_db {
+	sqlite3 *db;
+	hashtable_t *sqlite_stmts;
+};
+
+#define PID "pid"
+struct lua_process_context {
+	int pid;
+	struct lua_process_info_array *process_info_arr;
+	struct lua_mmap_info_array *mmap_info_arr;
+};
+
+struct lua_db *get_lua_db(lua_State *L);
+void get_global_pid_list(lua_State *L);
+void get_global_pid(lua_State *L, int pid);
+
+int process_index(lua_State *L);
+int get_process_by_pid(lua_State *L);
+
+void teardown_process_context(lua_State *L);
+void init_process_context(lua_State *L, sqlite3 *db, hashtable_t *sqlite_stmts);
+
+#endif // LUA_PROCESS_H

--- a/kalbur/rule_engine/lua/lua_process.h
+++ b/kalbur/rule_engine/lua/lua_process.h
@@ -19,6 +19,7 @@
 #include "lua_tcp_connection_info.h"
 #include "lua_module_load_info.h"
 #include "lua_modprobe_overwrite_info.h"
+#include "lua_process_lpe_info.h"
 
 #define GLOBAL_LUA_DB "SENSOR_DB"
 #define GLOBAL_PID_LIST "SENSOR_PID_LIST"
@@ -43,6 +44,7 @@ struct lua_process_context {
 	struct lua_tcp_connection_info_array *tcp_connection_info_arr;
 	struct lua_module_load_info_array *module_load_info_arr;
 	struct lua_modprobe_overwrite_info_array *modprobe_overwrite_info_arr;
+	struct lua_process_lpe_info_array *process_lpe_info_arr;
 };
 
 struct lua_db *get_lua_db(lua_State *L);

--- a/kalbur/rule_engine/lua/lua_process.h
+++ b/kalbur/rule_engine/lua/lua_process.h
@@ -17,6 +17,7 @@
 
 #define GLOBAL_LUA_DB "SENSOR_DB"
 #define GLOBAL_PID_LIST "SENSOR_PID_LIST"
+#define PROCESS_METATABLE "ProcessMetaTable"
 
 #define IS_ATTR(attr_name, attr) strncmp(attr_name, attr, sizeof(attr)) == 0
 

--- a/kalbur/rule_engine/lua/lua_process.h
+++ b/kalbur/rule_engine/lua/lua_process.h
@@ -15,6 +15,7 @@
 #include "lua_process_info.h"
 #include "lua_mmap_info.h"
 #include "lua_ptrace_info.h"
+#include "lua_socket_create_info.h"
 
 #define GLOBAL_LUA_DB "SENSOR_DB"
 #define GLOBAL_PID_LIST "SENSOR_PID_LIST"
@@ -35,6 +36,7 @@ struct lua_process_context {
 	struct lua_process_info_array *process_info_arr;
 	struct lua_mmap_info_array *mmap_info_arr;
 	struct lua_ptrace_info_array *ptrace_info_arr;
+	struct lua_socket_create_info_array *socket_create_info_arr;
 };
 
 struct lua_db *get_lua_db(lua_State *L);

--- a/kalbur/rule_engine/lua/lua_process.h
+++ b/kalbur/rule_engine/lua/lua_process.h
@@ -17,6 +17,7 @@
 #include "lua_ptrace_info.h"
 #include "lua_socket_create_info.h"
 #include "lua_tcp_connection_info.h"
+#include "lua_module_load_info.h"
 
 #define GLOBAL_LUA_DB "SENSOR_DB"
 #define GLOBAL_PID_LIST "SENSOR_PID_LIST"
@@ -39,6 +40,7 @@ struct lua_process_context {
 	struct lua_ptrace_info_array *ptrace_info_arr;
 	struct lua_socket_create_info_array *socket_create_info_arr;
 	struct lua_tcp_connection_info_array *tcp_connection_info_arr;
+	struct lua_module_load_info_array *module_load_info_arr;
 };
 
 struct lua_db *get_lua_db(lua_State *L);

--- a/kalbur/rule_engine/lua/lua_process_info.c
+++ b/kalbur/rule_engine/lua/lua_process_info.c
@@ -15,6 +15,25 @@ void delete_lua_process_info(struct lua_process_info *process_info)
 		delete_lua_event_info(process_info->event_info);
 	}
 
+	if (process_info->args != NULL) {
+		free(process_info->args);
+		process_info->args = NULL;
+	}
+
+	if (process_info->env != NULL) {
+		free(process_info->env);
+		process_info->env = NULL;
+	}
+
+	if (process_info->interpreter != NULL) {
+		free(process_info->interpreter);
+		process_info->interpreter = NULL;
+	}
+
+	if (process_info->file_info != NULL) {
+		delete_lua_file_info(process_info->file_info);
+	}
+
 	free(process_info);
 	process_info = NULL;
 }
@@ -42,4 +61,357 @@ void delete_lua_process_info_array(struct lua_process_info_array *arr)
 
 	free(arr);
 	arr = NULL;
+}
+
+/**
+ * @brief handle index access of process_info
+ * Expects stack to have string attribute at the top
+ * and process_info user data at position -2.
+ * returns nil if error occurs.
+ * 
+ * Stack: [-2, +1]
+ * @param L
+ * @return number of return values (1)
+ */
+int process_info_index(lua_State *L)
+{
+	struct lua_process_info *process_info;
+	const char *attribute;
+
+	ASSERT(lua_isuserdata(L, -2),
+	       "process_info_index: stack[-2] not userdata");
+
+	// make sure that the attribute is string
+	if (!lua_isstring(L, -1)) {
+		fprintf(stderr, "process_info_index: stack[-1] not string\n");
+		lua_pop(L, 2);
+		lua_pushnil(L);
+		return 1;
+	}
+
+	// get process_info light user data
+	lua_getuservalue(L, -2);
+	lua_pushstring(L, PROCESS_INFO);
+	lua_gettable(L, -2);
+	ASSERT(lua_isuserdata(L, -1),
+	       "process_info_index: process_info user value not found");
+
+	process_info = (struct lua_process_info *)lua_touserdata(L, -1);
+	ASSERT(process_info != NULL,
+	       "process_info_index: process_info is NULL");
+
+	lua_pop(L, 2);
+
+	// get string attribute
+	attribute = lua_tostring(L, -1);
+
+	// swap attribute and process_info user data
+	lua_rotate(L, -2, 1);
+	lua_pop(L, 1);
+
+	// handle attribute
+	if (IS_ATTR(attribute, EVENT_TIME)) {
+		lua_pop(L, 1);
+		lua_pushinteger(
+			L, (lua_Integer)process_info->event_info->event_time);
+		return 1;
+	} else if (IS_ATTR(attribute, SYSCALL)) {
+		lua_pop(L, 1);
+		lua_pushinteger(L,
+				(lua_Integer)process_info->event_info->syscall);
+		return 1;
+	} else if (IS_ATTR(attribute, PROCESS_NAME)) {
+		lua_pop(L, 1);
+		lua_pushstring(L, process_info->event_info->process_name);
+		return 1;
+	} else if (IS_ATTR(attribute, PARENT_PID_ATTR)) {
+		lua_pop(L, 1);
+		lua_pushinteger(L, (lua_Integer)process_info->parent_tgid);
+		return 1;
+	} else if (IS_ATTR(attribute, CLONE_FLAGS_ATTR)) {
+		lua_pop(L, 1);
+		lua_pushinteger(L, (lua_Integer)process_info->clone_flags);
+		return 1;
+	} else if (IS_ATTR(attribute, ARGS_ATTR)) {
+		lua_pop(L, 1);
+		lua_pushstring(L, (const char *)process_info->args);
+		return 1;
+	} else if (IS_ATTR(attribute, ENV_ATTR)) {
+		lua_pop(L, 1);
+		lua_pushstring(L, (const char *)process_info->env);
+		return 1;
+	} else if (IS_ATTR(attribute, INTERPRETER_ATTR)) {
+		lua_pop(L, 1);
+		lua_pushstring(L, (const char *)process_info->interpreter);
+		return 1;
+	} else if (IS_ATTR(attribute, UID_ATTR)) {
+		lua_pop(L, 1);
+		lua_pushinteger(L, (lua_Integer)process_info->uid);
+		return 1;
+	} else if (IS_ATTR(attribute, GID_ATTR)) {
+		lua_pop(L, 1);
+		lua_pushinteger(L, (lua_Integer)process_info->gid);
+		return 1;
+	} else if (IS_ATTR(attribute, EUID_ATTR)) {
+		lua_pop(L, 1);
+		lua_pushinteger(L, (lua_Integer)process_info->euid);
+		return 1;
+	} else if (IS_ATTR(attribute, EGID_ATTR)) {
+		lua_pop(L, 1);
+		lua_pushinteger(L, (lua_Integer)process_info->egid);
+		return 1;
+	} else if (IS_ATTR(attribute, STDIN_INODE_ATTR)) {
+		lua_pop(L, 1);
+		lua_pushinteger(L, (lua_Integer)process_info->stdin_inode);
+		return 1;
+	} else if (IS_ATTR(attribute, STDOUT_INODE_ATTR)) {
+		lua_pop(L, 1);
+		lua_pushinteger(L, (lua_Integer)process_info->stdout_inode);
+		return 1;
+	} else if (IS_ATTR(attribute, STDERR_INODE_ATTR)) {
+		lua_pop(L, 1);
+		lua_pushinteger(L, (lua_Integer)process_info->stderr_inode);
+		return 1;
+	} else if (IS_ATTR(attribute, STDIN_TYPE_ATTR)) {
+		lua_pop(L, 1);
+		lua_pushinteger(L, (lua_Integer)process_info->stdin_type);
+		return 1;
+	} else if (IS_ATTR(attribute, STDOUT_TYPE_ATTR)) {
+		lua_pop(L, 1);
+		lua_pushinteger(L, (lua_Integer)process_info->stdout_type);
+		return 1;
+	} else if (IS_ATTR(attribute, STDERR_TYPE_ATTR)) {
+		lua_pop(L, 1);
+		lua_pushinteger(L, (lua_Integer)process_info->stderr_type);
+		return 1;
+	} else if (IS_ATTR(attribute, FILE)) {
+		lua_pop(L, 1);
+		// stack is reset
+
+		lua_newuserdata(L, sizeof(struct lua_file_info));
+
+		// stores file_info (light user data) in a table as user value
+		// file_info_full_ud.userdata["FILE_INFO"] = file_info_light_ud
+		lua_newtable(L);
+		lua_pushstring(L, FILE_INFO);
+		lua_pushlightuserdata(L, process_info->file_info);
+		lua_settable(L, -3);
+
+		lua_setuservalue(L, -2);
+
+		// create new metatable and set its metamethods
+		luaL_newmetatable(L, FILE_INFO_METATABLE);
+
+		lua_pushstring(L, "__index");
+		lua_pushcfunction(L, file_info_index);
+		lua_settable(L, -3);
+
+		// sanity checks
+		ASSERT(lua_istable(L, -1), "");
+		ASSERT(lua_isuserdata(L, -2), "");
+
+		// set metatable of process context
+		lua_setmetatable(L, -2);
+
+		// make sure that we return file_info userdata
+		ASSERT(lua_isuserdata(L, -1), "");
+
+		return 1;
+	} else {
+		fprintf(stderr, "process_info_index: invalid attribute: %s\n",
+			attribute);
+		lua_pop(L, 1);
+		lua_pushnil(L);
+		return 1;
+	}
+}
+
+/**
+ * @brief handle index access of process_info_arr
+ * Expects stack to have integer attribute at the top
+ * and proces_context user data at position -2.
+ * returns nil if error occurs.
+ * Stack: [-2, +1]
+ * 
+ * @param L 
+ * @return Number of return values (1)
+ */
+int process_info_arr_index(lua_State *L)
+{
+	struct lua_process_info_array *process_info_arr;
+	struct lua_process_info *process_info;
+	int index;
+
+	if (!lua_isinteger(L, -1)) {
+		fprintf(stderr,
+			"process_info_arr_index: stack[-1] not integer\n");
+		lua_pop(L, 2);
+		lua_pushnil(L);
+		return 1;
+	}
+
+	// get the integer index
+	index = (int)lua_tointeger(L, -1);
+	ASSERT(lua_isuserdata(L, -2),
+	       "process_info_arr_index: stack[-2] not userdata");
+
+	// get process_info_arr_full_ud.userdata["PROCESS_INFO_ARR"]
+	// which is the light ud
+	lua_getuservalue(L, -2);
+	ASSERT(lua_istable(L, -1),
+	       "process_info_arr_index: stack[-1] not table");
+	lua_pushstring(L, PROCESS_INFO_ARR);
+	lua_gettable(L, -2);
+
+	process_info_arr =
+		(struct lua_process_info_array *)lua_touserdata(L, -1);
+	ASSERT(process_info_arr != NULL,
+	       "process_info_arr_index: process_info_arr == NULL");
+
+	lua_pop(L, 4);
+	// stack is reset
+
+	if (index <= 0 || index > process_info_arr->size) {
+		lua_pushnil(L);
+	} else {
+		process_info = process_info_arr->values[index - 1];
+		lua_newuserdata(L, sizeof(struct lua_process_info));
+
+		// stores process_info (light user data) in a table as user value
+		// process_info_full_ud.userdata["PROCESS_INFO"] = process_info_light_ud
+		lua_newtable(L);
+		lua_pushstring(L, PROCESS_INFO);
+		lua_pushlightuserdata(L, process_info);
+		lua_settable(L, -3);
+
+		lua_setuservalue(L, -2);
+
+		// create metatable and set some metamethods
+		luaL_newmetatable(L, PROCESS_INFO_METATABLE);
+
+		lua_pushstring(L, "__index");
+		lua_pushcfunction(L, process_info_index);
+		lua_settable(L, -3);
+
+		// sanity checks
+		ASSERT(lua_istable(L, -1), "");
+		ASSERT(lua_isuserdata(L, -2), "");
+
+		// set metatable of process context
+		lua_setmetatable(L, -2);
+
+		// make sure that we return process_info user data
+		ASSERT(lua_isuserdata(L, -1),
+		       "process_info_arr_index: stack[-1] not userdata");
+	}
+
+	return 1;
+}
+
+/**
+ * @brief Get the process_info array length
+ * Expects the process_info_array userdata on the top of the stack
+ * Stack: [-1, +1]
+ * 
+ * @param L The lua state
+ * @return Number of return values (1)
+ */
+int process_info_arr_len(lua_State *L)
+{
+	struct lua_process_info_array *process_info_arr;
+
+	ASSERT(lua_isuserdata(L, -1),
+	       "process_info_arr_len: stack[-2] not userdata");
+
+	// get process_info_arr_full_ud.userdata["PROCESS_INFO_ARR"]
+	// which is the light ud
+	lua_getuservalue(L, -1);
+	ASSERT(lua_istable(L, -1), "process_info_arr_len: stack[-1] not table");
+	lua_pushstring(L, PROCESS_INFO_ARR);
+	lua_gettable(L, -2);
+
+	process_info_arr =
+		(struct lua_process_info_array *)lua_touserdata(L, -1);
+	ASSERT(process_info_arr != NULL,
+	       "process_info_arr_len: process_info_arr == NULL");
+
+	lua_pop(L, 3);
+	// stack is reset
+
+	// return the size of the process_info_arr
+	lua_pushinteger(L, (lua_Integer)process_info_arr->size);
+
+	return 1;
+}
+
+/**
+ * @brief Get the process_info object, initialize it, populate data from db.
+ * Stack: [-1, +1]
+ * 
+ * @param L The lua state.
+ */
+void get_process_info(lua_State *L)
+{
+	struct lua_process_context *process_context;
+	struct lua_process_info_array *process_info_arr;
+	struct lua_db *db;
+
+	process_context = (struct lua_process_context *)lua_touserdata(L, -1);
+	if (process_context == NULL) {
+		fprintf(stderr, "get_process_info: process_context == NULL\n");
+		lua_pop(L, 1);
+		lua_pushnil(L);
+		return;
+	}
+
+	if (process_context->process_info_arr != NULL) {
+		process_info_arr = process_context->process_info_arr;
+	} else {
+		process_info_arr = (struct lua_process_info_array *)malloc(
+			sizeof(struct lua_process_info_array));
+		process_info_arr->max_size = PROCESS_INFO_CHUNK_SIZE;
+		process_info_arr->size = 0;
+		process_info_arr->values = (struct lua_process_info **)malloc(
+			sizeof(struct lua_process_info *) *
+			(size_t)process_info_arr->max_size);
+
+		db = get_lua_db(L);
+
+		select_all_process_info(db->db, db->sqlite_stmts,
+					process_info_arr, process_context->pid);
+		process_context->process_info_arr = process_info_arr;
+	}
+
+	lua_pop(L, 1);
+	// stack is reset
+
+	lua_newuserdata(L, sizeof(struct lua_process_info_array));
+
+	// stores process_info_arr (light user data) in a table as user value
+	// process_info_arr_full_ud.userdata["PROCESS_INFO_ARR"] = process_info_arr_light_ud
+	lua_newtable(L);
+	lua_pushstring(L, PROCESS_INFO_ARR);
+	lua_pushlightuserdata(L, process_info_arr);
+	lua_settable(L, -3);
+	lua_setuservalue(L, -2);
+
+	// create metatable and set some metamethods
+	luaL_newmetatable(L, PROCESS_INFO_ARR_METATABLE);
+
+	lua_pushstring(L, "__index");
+	lua_pushcfunction(L, process_info_arr_index);
+	lua_settable(L, -3);
+
+	lua_pushstring(L, "__len");
+	lua_pushcfunction(L, process_info_arr_len);
+	lua_settable(L, -3);
+
+	// sanity checks
+	ASSERT(lua_istable(L, -1), "");
+	ASSERT(lua_isuserdata(L, -2), "");
+
+	lua_setmetatable(L, -2);
+
+	// make sure we return the process_info_arr
+	ASSERT(lua_isuserdata(L, -1), "");
 }

--- a/kalbur/rule_engine/lua/lua_process_info.c
+++ b/kalbur/rule_engine/lua/lua_process_info.c
@@ -1,0 +1,45 @@
+#include "lua_process_info.h"
+
+/**
+ * @brief Frees lua_process_info
+ * 
+ * @param event_info 
+ */
+void delete_lua_process_info(struct lua_process_info *process_info)
+{
+	if (process_info == NULL) {
+		return;
+	}
+
+	if (process_info->event_info != NULL) {
+		delete_lua_event_info(process_info->event_info);
+	}
+
+	free(process_info);
+	process_info = NULL;
+}
+
+/**
+ * @brief Frees lua_process_info_array
+ * 
+ * @param event_info 
+ */
+void delete_lua_process_info_array(struct lua_process_info_array *arr)
+{
+	if (arr == NULL) {
+		return;
+	}
+
+	if (arr->size > 0) {
+		for (int i = 0; i < arr->size; i++) {
+			delete_lua_process_info(arr->values[i]);
+		}
+	}
+
+	arr->size = 0;
+	free(arr->values);
+	arr->values = NULL;
+
+	free(arr);
+	arr = NULL;
+}

--- a/kalbur/rule_engine/lua/lua_process_info.h
+++ b/kalbur/rule_engine/lua/lua_process_info.h
@@ -4,12 +4,44 @@
 #include <lua_process.h>
 
 #define PROCESS_INFO_CHUNK_SIZE 100
-#define PROCESS_METATABLE "ProcessMetaTable"
+#define PROCESS_INFO_ARR_METATABLE "ProcessInfoArrMetaTable"
+#define PROCESS_INFO_METATABLE "ProcessInfoMetaTable"
+#define PROCESS_INFO_ARR "ProcessInfoArr"
 #define PROCESS_INFO "ProcessInfo"
 
+#define PARENT_PID_ATTR "ppid"
+#define CLONE_FLAGS_ATTR "clone_flags"
+#define ARGS_ATTR "args"
+#define ENV_ATTR "env"
+#define INTERPRETER_ATTR "interpreter"
+#define UID_ATTR "uid"
+#define GID_ATTR "gid"
+#define EUID_ATTR "euid"
+#define EGID_ATTR "egid"
+#define STDIN_INODE_ATTR "stdin_inode"
+#define STDOUT_INODE_ATTR "stdout_inode"
+#define STDERR_INODE_ATTR "stderr_inode"
+#define STDIN_TYPE_ATTR "stdin_type"
+#define STDOUT_TYPE_ATTR "stdout_type"
+#define STDERR_TYPE_ATTR "stderr_type"
 struct lua_process_info {
 	struct lua_event_info *event_info;
-	u64_t ppid;
+	u64_t parent_tgid;
+	u64_t clone_flags;
+	char *args;
+	char *env;
+	char *interpreter;
+	int uid;
+	int gid;
+	int euid;
+	int egid;
+	int stdin_inode;
+	int stdin_type;
+	int stdout_inode;
+	int stdout_type;
+	int stderr_inode;
+	int stderr_type;
+	struct lua_file_info *file_info;
 };
 
 typedef struct lua_process_info_array {
@@ -20,5 +52,11 @@ typedef struct lua_process_info_array {
 
 void delete_lua_process_info(struct lua_process_info *process_info);
 void delete_lua_process_info_array(struct lua_process_info_array *arr);
+
+int process_info_index(lua_State *L);
+int process_info_arr_index(lua_State *L);
+int process_info_arr_len(lua_State *L);
+
+void get_process_info(lua_State *L);
 
 #endif // LUA_PROCESS_INFO_H

--- a/kalbur/rule_engine/lua/lua_process_info.h
+++ b/kalbur/rule_engine/lua/lua_process_info.h
@@ -1,0 +1,24 @@
+#ifndef LUA_PROCESS_INFO_H
+#define LUA_PROCESS_INFO_H
+
+#include <lua_process.h>
+
+#define PROCESS_INFO_CHUNK_SIZE 100
+#define PROCESS_METATABLE "ProcessMetaTable"
+#define PROCESS_INFO "ProcessInfo"
+
+struct lua_process_info {
+	struct lua_event_info *event_info;
+	u64_t ppid;
+};
+
+typedef struct lua_process_info_array {
+	int max_size;
+	int size;
+	struct lua_process_info **values;
+} lua_process_info_array;
+
+void delete_lua_process_info(struct lua_process_info *process_info);
+void delete_lua_process_info_array(struct lua_process_info_array *arr);
+
+#endif // LUA_PROCESS_INFO_H

--- a/kalbur/rule_engine/lua/lua_process_lpe_info.c
+++ b/kalbur/rule_engine/lua/lua_process_lpe_info.c
@@ -1,0 +1,327 @@
+#include "lua_process_lpe_info.h"
+
+/**
+ * @brief Frees lua_process_lpe_info
+ * 
+ * @param event_info 
+ */
+void delete_lua_process_lpe_info(struct lua_process_lpe_info *process_lpe_info)
+{
+	if (process_lpe_info == NULL) {
+		return;
+	}
+
+	if (process_lpe_info->event_info != NULL) {
+		delete_lua_event_info(process_lpe_info->event_info);
+	}
+
+	if (process_lpe_info->target_func != NULL) {
+		free(process_lpe_info->target_func);
+		process_lpe_info->target_func = NULL;
+	}
+
+	free(process_lpe_info);
+	process_lpe_info = NULL;
+}
+
+/**
+ * @brief Frees lua_process_lpe_info_array
+ * 
+ * @param event_info 
+ */
+void delete_lua_process_lpe_info_array(struct lua_process_lpe_info_array *arr)
+{
+	if (arr == NULL) {
+		return;
+	}
+
+	if (arr->size > 0) {
+		for (int i = 0; i < arr->size; i++) {
+			delete_lua_process_lpe_info(arr->values[i]);
+		}
+	}
+
+	arr->size = 0;
+	free(arr->values);
+	arr->values = NULL;
+
+	free(arr);
+	arr = NULL;
+}
+
+/**
+ * @brief handle index access of process_lpe_info
+ * Expects stack to have string attribute at the top
+ * and process_lpe_info user data at position -2.
+ * returns nil if error occurs.
+ * 
+ * Stack: [-2, +1]
+ * @param L
+ * @return number of return values (1)
+ */
+int process_lpe_info_index(lua_State *L)
+{
+	struct lua_process_lpe_info *process_lpe_info;
+	const char *attribute;
+
+	ASSERT(lua_isuserdata(L, -2),
+	       "process_lpe_info_index: stack[-2] not userdata");
+
+	// make sure that the attribute is string
+	if (!lua_isstring(L, -1)) {
+		fprintf(stderr,
+			"process_lpe_info_index: stack[-1] not string\n");
+		lua_pop(L, 2);
+		lua_pushnil(L);
+		return 1;
+	}
+
+	// get process_lpe_info light user data
+	lua_getuservalue(L, -2);
+	lua_pushstring(L, PROCESS_LPE_INFO);
+	lua_gettable(L, -2);
+	ASSERT(lua_isuserdata(L, -1),
+	       "process_lpe_info_index: process_lpe_info user value not found");
+
+	process_lpe_info = (struct lua_process_lpe_info *)lua_touserdata(L, -1);
+	ASSERT(process_lpe_info != NULL,
+	       "process_lpe_info_index: process_lpe_info is NULL");
+
+	lua_pop(L, 2);
+
+	// get string attribute
+	attribute = lua_tostring(L, -1);
+
+	// swap attribute and process_lpe_info user data
+	lua_rotate(L, -2, 1);
+	lua_pop(L, 1);
+
+	// handle attribute
+	if (IS_ATTR(attribute, EVENT_TIME)) {
+		lua_pop(L, 1);
+		lua_pushinteger(
+			L,
+			(lua_Integer)process_lpe_info->event_info->event_time);
+		return 1;
+	} else if (IS_ATTR(attribute, SYSCALL)) {
+		lua_pop(L, 1);
+		lua_pushinteger(
+			L, (lua_Integer)process_lpe_info->event_info->syscall);
+		return 1;
+	} else if (IS_ATTR(attribute, PROCESS_NAME)) {
+		lua_pop(L, 1);
+		lua_pushstring(L, process_lpe_info->event_info->process_name);
+		return 1;
+	} else if (IS_ATTR(attribute, CALLER_RET_ADDR_ATTR)) {
+		lua_pop(L, 1);
+		lua_pushinteger(L,
+				(lua_Integer)process_lpe_info->caller_ret_addr);
+		return 1;
+	} else if (IS_ATTR(attribute, TARGET_FUNC_ATTR)) {
+		lua_pop(L, 1);
+		lua_pushstring(L, process_lpe_info->target_func);
+		return 1;
+	} else {
+		fprintf(stderr,
+			"process_lpe_info_index: invalid attribute: %s\n",
+			attribute);
+		lua_pop(L, 1);
+		lua_pushnil(L);
+		return 1;
+	}
+}
+
+/**
+ * @brief handle index access of process_lpe_info_arr
+ * Expects stack to have integer attribute at the top
+ * and proces_context user data at position -2.
+ * returns nil if error occurs.
+ * Stack: [-2, +1]
+ * 
+ * @param L 
+ * @return Number of return values (1)
+ */
+int process_lpe_info_arr_index(lua_State *L)
+{
+	struct lua_process_lpe_info_array *process_lpe_info_arr;
+	struct lua_process_lpe_info *process_lpe_info;
+	int index;
+
+	if (!lua_isinteger(L, -1)) {
+		fprintf(stderr,
+			"process_lpe_info_arr_index: stack[-1] not integer\n");
+		lua_pop(L, 2);
+		lua_pushnil(L);
+		return 1;
+	}
+
+	// get the integer index
+	index = (int)lua_tointeger(L, -1);
+	ASSERT(lua_isuserdata(L, -2),
+	       "process_lpe_info_arr_index: stack[-2] not userdata");
+
+	// get process_lpe_info_arr_full_ud.userdata["PROCESS_LPE_INFO_ARR"]
+	// which is the light ud
+	lua_getuservalue(L, -2);
+	ASSERT(lua_istable(L, -1),
+	       "process_lpe_info_arr_index: stack[-1] not table");
+	lua_pushstring(L, PROCESS_LPE_INFO_ARR);
+	lua_gettable(L, -2);
+
+	process_lpe_info_arr =
+		(struct lua_process_lpe_info_array *)lua_touserdata(L, -1);
+	ASSERT(process_lpe_info_arr != NULL,
+	       "process_lpe_info_arr_index: process_lpe_info_arr == NULL");
+
+	lua_pop(L, 4);
+	// stack is reset
+
+	if (index <= 0 || index > process_lpe_info_arr->size) {
+		lua_pushnil(L);
+	} else {
+		process_lpe_info = process_lpe_info_arr->values[index - 1];
+		lua_newuserdata(L, sizeof(struct lua_process_lpe_info));
+
+		// stores process_lpe_info (light user data) in a table as user value
+		// process_lpe_info_full_ud.userdata["PROCESS_LPE_INFO"] = process_lpe_info_light_ud
+		lua_newtable(L);
+		lua_pushstring(L, PROCESS_LPE_INFO);
+		lua_pushlightuserdata(L, process_lpe_info);
+		lua_settable(L, -3);
+
+		lua_setuservalue(L, -2);
+
+		// create metatable and set some metamethods
+		luaL_newmetatable(L, PROCESS_LPE_INFO_METATABLE);
+
+		lua_pushstring(L, "__index");
+		lua_pushcfunction(L, process_lpe_info_index);
+		lua_settable(L, -3);
+
+		// sanity checks
+		ASSERT(lua_istable(L, -1), "");
+		ASSERT(lua_isuserdata(L, -2), "");
+
+		// set metatable of process context
+		lua_setmetatable(L, -2);
+
+		// make sure that we return process_lpe_info user data
+		ASSERT(lua_isuserdata(L, -1),
+		       "process_lpe_info_arr_index: stack[-1] not userdata");
+	}
+
+	return 1;
+}
+
+/**
+ * @brief Get the process_lpe_info array length
+ * Expects the process_lpe_info_array userdata on the top of the stack
+ * Stack: [-1, +1]
+ * 
+ * @param L The lua state
+ * @return Number of return values (1)
+ */
+int process_lpe_info_arr_len(lua_State *L)
+{
+	struct lua_process_lpe_info_array *process_lpe_info_arr;
+
+	ASSERT(lua_isuserdata(L, -1),
+	       "process_lpe_info_arr_len: stack[-2] not userdata");
+
+	// get process_lpe_info_arr_full_ud.userdata["PROCESS_LPE_INFO_ARR"]
+	// which is the light ud
+	lua_getuservalue(L, -1);
+	ASSERT(lua_istable(L, -1),
+	       "process_lpe_info_arr_len: stack[-1] not table");
+	lua_pushstring(L, PROCESS_LPE_INFO_ARR);
+	lua_gettable(L, -2);
+
+	process_lpe_info_arr =
+		(struct lua_process_lpe_info_array *)lua_touserdata(L, -1);
+	ASSERT(process_lpe_info_arr != NULL,
+	       "process_lpe_info_arr_len: process_lpe_info_arr == NULL");
+
+	lua_pop(L, 3);
+	// stack is reset
+
+	// return the size of the process_lpe_info_arr
+	lua_pushinteger(L, (lua_Integer)process_lpe_info_arr->size);
+
+	return 1;
+}
+
+/**
+ * @brief Get the process_lpe_info object, initialize it, populate data from db.
+ * Stack: [-1, +1]
+ * 
+ * @param L The lua state.
+ */
+void get_process_lpe_info(lua_State *L)
+{
+	struct lua_process_context *process_context;
+	struct lua_process_lpe_info_array *process_lpe_info_arr;
+	struct lua_db *db;
+
+	process_context = (struct lua_process_context *)lua_touserdata(L, -1);
+	if (process_context == NULL) {
+		fprintf(stderr,
+			"get_process_lpe_info: process_context == NULL\n");
+		lua_pop(L, 1);
+		lua_pushnil(L);
+		return;
+	}
+
+	if (process_context->process_lpe_info_arr != NULL) {
+		process_lpe_info_arr = process_context->process_lpe_info_arr;
+	} else {
+		process_lpe_info_arr =
+			(struct lua_process_lpe_info_array *)malloc(
+				sizeof(struct lua_process_lpe_info_array));
+		process_lpe_info_arr->max_size = PROCESS_LPE_INFO_CHUNK_SIZE;
+		process_lpe_info_arr->size = 0;
+		process_lpe_info_arr->values =
+			(struct lua_process_lpe_info **)malloc(
+				sizeof(struct lua_process_lpe_info *) *
+				(size_t)process_lpe_info_arr->max_size);
+
+		db = get_lua_db(L);
+
+		select_all_process_lpe_info(db->db, db->sqlite_stmts,
+					    process_lpe_info_arr,
+					    process_context->pid);
+		process_context->process_lpe_info_arr = process_lpe_info_arr;
+	}
+
+	lua_pop(L, 1);
+	// stack is reset
+
+	lua_newuserdata(L, sizeof(struct lua_process_lpe_info_array));
+
+	// stores process_lpe_info_arr (light user data) in a table as user value
+	// process_lpe_info_arr_full_ud.userdata["PROCESS_LPE_INFO_ARR"] = process_lpe_info_arr_light_ud
+	lua_newtable(L);
+	lua_pushstring(L, PROCESS_LPE_INFO_ARR);
+	lua_pushlightuserdata(L, process_lpe_info_arr);
+	lua_settable(L, -3);
+	lua_setuservalue(L, -2);
+
+	// create metatable and set some metamethods
+	luaL_newmetatable(L, PROCESS_LPE_INFO_ARR_METATABLE);
+
+	lua_pushstring(L, "__index");
+	lua_pushcfunction(L, process_lpe_info_arr_index);
+	lua_settable(L, -3);
+
+	lua_pushstring(L, "__len");
+	lua_pushcfunction(L, process_lpe_info_arr_len);
+	lua_settable(L, -3);
+
+	// sanity checks
+	ASSERT(lua_istable(L, -1), "");
+	ASSERT(lua_isuserdata(L, -2), "");
+
+	lua_setmetatable(L, -2);
+
+	// make sure we return the process_lpe_info_arr
+	ASSERT(lua_isuserdata(L, -1), "");
+}

--- a/kalbur/rule_engine/lua/lua_process_lpe_info.h
+++ b/kalbur/rule_engine/lua/lua_process_lpe_info.h
@@ -1,0 +1,35 @@
+#ifndef LUA_PROCESS_LPE_INFO_H
+#define LUA_PROCESS_LPE_INFO_H
+
+#include <lua_process.h>
+
+#define PROCESS_LPE_INFO_CHUNK_SIZE 100
+#define PROCESS_LPE_INFO_ARR_METATABLE "ProcessLPEInfoArrMetaTable"
+#define PROCESS_LPE_INFO_METATABLE "ProcessLPEInfoMetaTable"
+#define PROCESS_LPE_INFO_ARR "ProcessLPEInfoArr"
+#define PROCESS_LPE_INFO "ProcessLPEInfo"
+
+#define CALLER_RET_ADDR_ATTR "caller_ret_addr"
+#define TARGET_FUNC_ATTR "target_func"
+struct lua_process_lpe_info {
+	struct lua_event_info *event_info;
+	u64_t caller_ret_addr;
+	char *target_func;
+};
+
+typedef struct lua_process_lpe_info_array {
+	int max_size;
+	int size;
+	struct lua_process_lpe_info **values;
+} lua_process_lpe_info_array;
+
+void delete_lua_process_lpe_info(struct lua_process_lpe_info *process_lpe_info);
+void delete_lua_process_lpe_info_array(struct lua_process_lpe_info_array *arr);
+
+int process_lpe_info_index(lua_State *L);
+int process_lpe_info_arr_index(lua_State *L);
+int process_lpe_info_arr_len(lua_State *L);
+
+void get_process_lpe_info(lua_State *L);
+
+#endif // LUA_PROCESS_LPE_INFO_H

--- a/kalbur/rule_engine/lua/lua_ptrace_info.c
+++ b/kalbur/rule_engine/lua/lua_ptrace_info.c
@@ -1,0 +1,314 @@
+#include "lua_ptrace_info.h"
+
+/**
+ * @brief Frees lua_ptrace_info
+ * 
+ * @param event_info 
+ */
+void delete_lua_ptrace_info(struct lua_ptrace_info *ptrace_info)
+{
+	if (ptrace_info == NULL) {
+		return;
+	}
+
+	if (ptrace_info->event_info != NULL) {
+		delete_lua_event_info(ptrace_info->event_info);
+	}
+
+	free(ptrace_info);
+	ptrace_info = NULL;
+}
+
+/**
+ * @brief Frees lua_ptrace_info_array
+ * 
+ * @param event_info 
+ */
+void delete_lua_ptrace_info_array(struct lua_ptrace_info_array *arr)
+{
+	if (arr == NULL) {
+		return;
+	}
+
+	if (arr->size > 0) {
+		for (int i = 0; i < arr->size; i++) {
+			delete_lua_ptrace_info(arr->values[i]);
+		}
+	}
+
+	arr->size = 0;
+	free(arr->values);
+	arr->values = NULL;
+
+	free(arr);
+	arr = NULL;
+}
+
+/**
+ * @brief handle index access of ptrace_info
+ * Expects stack to have string attribute at the top
+ * and ptrace_info user data at position -2.
+ * returns nil if error occurs.
+ * 
+ * Stack: [-2, +1]
+ * @param L
+ * @return number of return values (1)
+ */
+int ptrace_info_index(lua_State *L)
+{
+	struct lua_ptrace_info *ptrace_info;
+	const char *attribute;
+
+	ASSERT(lua_isuserdata(L, -2),
+	       "ptrace_info_index: stack[-2] not userdata");
+
+	// make sure that the attribute is string
+	if (!lua_isstring(L, -1)) {
+		fprintf(stderr, "ptrace_info_index: stack[-1] not string\n");
+		lua_pop(L, 2);
+		lua_pushnil(L);
+		return 1;
+	}
+
+	// get ptrace_info light user data
+	lua_getuservalue(L, -2);
+	lua_pushstring(L, PTRACE_INFO);
+	lua_gettable(L, -2);
+	ASSERT(lua_isuserdata(L, -1),
+	       "ptrace_info_index: ptrace_info user value not found");
+
+	ptrace_info = (struct lua_ptrace_info *)lua_touserdata(L, -1);
+	ASSERT(ptrace_info != NULL, "ptrace_info_index: ptrace_info is NULL");
+
+	lua_pop(L, 2);
+
+	// get string attribute
+	attribute = lua_tostring(L, -1);
+
+	// swap attribute and ptrace_info user data
+	lua_rotate(L, -2, 1);
+	lua_pop(L, 1);
+
+	// handle attribute
+	if (IS_ATTR(attribute, EVENT_TIME)) {
+		lua_pop(L, 1);
+		lua_pushinteger(
+			L, (lua_Integer)ptrace_info->event_info->event_time);
+		return 1;
+	} else if (IS_ATTR(attribute, SYSCALL)) {
+		lua_pop(L, 1);
+		lua_pushinteger(L,
+				(lua_Integer)ptrace_info->event_info->syscall);
+		return 1;
+	} else if (IS_ATTR(attribute, PROCESS_NAME)) {
+		lua_pop(L, 1);
+		lua_pushstring(L, ptrace_info->event_info->process_name);
+		return 1;
+	} else if (IS_ATTR(attribute, REQUEST_ATTR)) {
+		lua_pop(L, 1);
+		lua_pushinteger(L, (lua_Integer)ptrace_info->request);
+		return 1;
+	} else if (IS_ATTR(attribute, ADDR_ATTR)) {
+		lua_pop(L, 1);
+		lua_pushinteger(L, (lua_Integer)ptrace_info->addr);
+		return 1;
+	} else if (IS_ATTR(attribute, TARGET_TGID_ATTR)) {
+		lua_pop(L, 1);
+		lua_pushinteger(L, (lua_Integer)ptrace_info->target_tgid);
+		return 1;
+	} else {
+		fprintf(stderr, "ptrace_info_index: invalid attribute: %s\n",
+			attribute);
+		lua_pop(L, 1);
+		lua_pushnil(L);
+		return 1;
+	}
+}
+
+/**
+ * @brief handle index access of ptrace_info_arr
+ * Expects stack to have integer attribute at the top
+ * and proces_context user data at position -2.
+ * returns nil if error occurs.
+ * Stack: [-2, +1]
+ * 
+ * @param L 
+ * @return Number of return values (1)
+ */
+int ptrace_info_arr_index(lua_State *L)
+{
+	struct lua_ptrace_info_array *ptrace_info_arr;
+	struct lua_ptrace_info *ptrace_info;
+	int index;
+
+	if (!lua_isinteger(L, -1)) {
+		fprintf(stderr,
+			"ptrace_info_arr_index: stack[-1] not integer\n");
+		lua_pop(L, 2);
+		lua_pushnil(L);
+		return 1;
+	}
+
+	// get the integer index
+	index = (int)lua_tointeger(L, -1);
+	ASSERT(lua_isuserdata(L, -2),
+	       "ptrace_info_arr_index: stack[-2] not userdata");
+
+	// get ptrace_info_arr_full_ud.userdata["PTRACE_INFO_ARR"]
+	// which is the light ud
+	lua_getuservalue(L, -2);
+	ASSERT(lua_istable(L, -1),
+	       "ptrace_info_arr_index: stack[-1] not table");
+	lua_pushstring(L, PTRACE_INFO_ARR);
+	lua_gettable(L, -2);
+
+	ptrace_info_arr = (struct lua_ptrace_info_array *)lua_touserdata(L, -1);
+	ASSERT(ptrace_info_arr != NULL,
+	       "ptrace_info_arr_index: ptrace_info_arr == NULL");
+
+	lua_pop(L, 4);
+	// stack is reset
+
+	if (index <= 0 || index > ptrace_info_arr->size) {
+		lua_pushnil(L);
+	} else {
+		ptrace_info = ptrace_info_arr->values[index - 1];
+		lua_newuserdata(L, sizeof(struct lua_ptrace_info));
+
+		// stores ptrace_info (light user data) in a table as user value
+		// ptrace_info_full_ud.userdata["PTRACE_INFO"] = ptrace_info_light_ud
+		lua_newtable(L);
+		lua_pushstring(L, PTRACE_INFO);
+		lua_pushlightuserdata(L, ptrace_info);
+		lua_settable(L, -3);
+
+		lua_setuservalue(L, -2);
+
+		// create metatable and set some metamethods
+		luaL_newmetatable(L, PTRACE_INFO_METATABLE);
+
+		lua_pushstring(L, "__index");
+		lua_pushcfunction(L, ptrace_info_index);
+		lua_settable(L, -3);
+
+		// sanity checks
+		ASSERT(lua_istable(L, -1), "");
+		ASSERT(lua_isuserdata(L, -2), "");
+
+		// set metatable of process context
+		lua_setmetatable(L, -2);
+
+		// make sure that we return ptrace_info user data
+		ASSERT(lua_isuserdata(L, -1),
+		       "ptrace_info_arr_index: stack[-1] not userdata");
+	}
+
+	return 1;
+}
+
+/**
+ * @brief Get the ptrace_info array length
+ * Expects the ptrace_info_array userdata on the top of the stack
+ * Stack: [-1, +1]
+ * 
+ * @param L The lua state
+ * @return Number of return values (1)
+ */
+int ptrace_info_arr_len(lua_State *L)
+{
+	struct lua_ptrace_info_array *ptrace_info_arr;
+
+	ASSERT(lua_isuserdata(L, -1),
+	       "ptrace_info_arr_len: stack[-2] not userdata");
+
+	// get ptrace_info_arr_full_ud.userdata["PTRACE_INFO_ARR"]
+	// which is the light ud
+	lua_getuservalue(L, -1);
+	ASSERT(lua_istable(L, -1), "ptrace_info_arr_len: stack[-1] not table");
+	lua_pushstring(L, PTRACE_INFO_ARR);
+	lua_gettable(L, -2);
+
+	ptrace_info_arr = (struct lua_ptrace_info_array *)lua_touserdata(L, -1);
+	ASSERT(ptrace_info_arr != NULL,
+	       "ptrace_info_arr_len: ptrace_info_arr == NULL");
+
+	lua_pop(L, 3);
+	// stack is reset
+
+	// return the size of the ptrace_info_arr
+	lua_pushinteger(L, (lua_Integer)ptrace_info_arr->size);
+
+	return 1;
+}
+
+/**
+ * @brief Get the ptrace_info object, initialize it, populate data from db.
+ * Stack: [-1, +1]
+ * 
+ * @param L The lua state.
+ */
+void get_ptrace_info(lua_State *L)
+{
+	struct lua_process_context *process_context;
+	struct lua_ptrace_info_array *ptrace_info_arr;
+	struct lua_db *db;
+
+	process_context = (struct lua_process_context *)lua_touserdata(L, -1);
+	if (process_context == NULL) {
+		fprintf(stderr, "get_ptrace_info: process_context == NULL\n");
+		lua_pop(L, 1);
+		lua_pushnil(L);
+		return;
+	}
+
+	if (process_context->ptrace_info_arr != NULL) {
+		ptrace_info_arr = process_context->ptrace_info_arr;
+	} else {
+		ptrace_info_arr = (struct lua_ptrace_info_array *)malloc(
+			sizeof(struct lua_ptrace_info_array));
+		ptrace_info_arr->max_size = PTRACE_INFO_CHUNK_SIZE;
+		ptrace_info_arr->size = 0;
+		ptrace_info_arr->values = (struct lua_ptrace_info **)malloc(
+			sizeof(struct lua_ptrace_info *) *
+			(size_t)ptrace_info_arr->max_size);
+
+		db = get_lua_db(L);
+
+		select_all_ptrace_info(db->db, db->sqlite_stmts,
+				       ptrace_info_arr, process_context->pid);
+		process_context->ptrace_info_arr = ptrace_info_arr;
+	}
+
+	lua_pop(L, 1);
+	// stack is reset
+
+	lua_newuserdata(L, sizeof(struct lua_ptrace_info_array));
+
+	// stores ptrace_info_arr (light user data) in a table as user value
+	// ptrace_info_arr_full_ud.userdata["PTRACE_INFO_ARR"] = ptrace_info_arr_light_ud
+	lua_newtable(L);
+	lua_pushstring(L, PTRACE_INFO_ARR);
+	lua_pushlightuserdata(L, ptrace_info_arr);
+	lua_settable(L, -3);
+	lua_setuservalue(L, -2);
+
+	// create metatable and set some metamethods
+	luaL_newmetatable(L, PTRACE_INFO_ARR_METATABLE);
+
+	lua_pushstring(L, "__index");
+	lua_pushcfunction(L, ptrace_info_arr_index);
+	lua_settable(L, -3);
+
+	lua_pushstring(L, "__len");
+	lua_pushcfunction(L, ptrace_info_arr_len);
+	lua_settable(L, -3);
+
+	// sanity checks
+	ASSERT(lua_istable(L, -1), "");
+	ASSERT(lua_isuserdata(L, -2), "");
+
+	lua_setmetatable(L, -2);
+
+	// make sure we return the ptrace_info_arr
+	ASSERT(lua_isuserdata(L, -1), "");
+}

--- a/kalbur/rule_engine/lua/lua_ptrace_info.h
+++ b/kalbur/rule_engine/lua/lua_ptrace_info.h
@@ -1,0 +1,37 @@
+#ifndef LUA_PTRACE_INFO_H
+#define LUA_PTRACE_INFO_H
+
+#include <lua_process.h>
+
+#define PTRACE_INFO_CHUNK_SIZE 100
+#define PTRACE_INFO_ARR_METATABLE "PtraceInfoArrMetaTable"
+#define PTRACE_INFO_METATABLE "PtraceInfoMetaTable"
+#define PTRACE_INFO_ARR "PtraceInfoArr"
+#define PTRACE_INFO "PtraceInfo"
+
+#define REQUEST_ATTR "request"
+#define ADDR_ATTR "addr"
+#define TARGET_TGID_ATTR "target_pid"
+struct lua_ptrace_info {
+	struct lua_event_info *event_info;
+	u64_t request;
+	u64_t addr;
+	u64_t target_tgid;
+};
+
+typedef struct lua_ptrace_info_array {
+	int max_size;
+	int size;
+	struct lua_ptrace_info **values;
+} lua_ptrace_info_array;
+
+void delete_lua_ptrace_info(struct lua_ptrace_info *ptrace_info);
+void delete_lua_ptrace_info_array(struct lua_ptrace_info_array *arr);
+
+int ptrace_info_index(lua_State *L);
+int ptrace_info_arr_index(lua_State *L);
+int ptrace_info_arr_len(lua_State *L);
+
+void get_ptrace_info(lua_State *L);
+
+#endif // LUA_PTRACE_INFO_H

--- a/kalbur/rule_engine/lua/lua_socket_create_info.c
+++ b/kalbur/rule_engine/lua/lua_socket_create_info.c
@@ -16,6 +16,16 @@ void delete_lua_socket_create_info(
 		delete_lua_event_info(socket_create_info->event_info);
 	}
 
+	if (socket_create_info->family != NULL) {
+		free(socket_create_info->family);
+		socket_create_info->family = NULL;
+	}
+
+	if (socket_create_info->socket_type != NULL) {
+		free(socket_create_info->socket_type);
+		socket_create_info->socket_type = NULL;
+	}
+
 	free(socket_create_info);
 	socket_create_info = NULL;
 }

--- a/kalbur/rule_engine/lua/lua_socket_create_info.c
+++ b/kalbur/rule_engine/lua/lua_socket_create_info.c
@@ -1,0 +1,331 @@
+#include "lua_socket_create_info.h"
+
+/**
+ * @brief Frees lua_socket_create_info
+ * 
+ * @param event_info 
+ */
+void delete_lua_socket_create_info(
+	struct lua_socket_create_info *socket_create_info)
+{
+	if (socket_create_info == NULL) {
+		return;
+	}
+
+	if (socket_create_info->event_info != NULL) {
+		delete_lua_event_info(socket_create_info->event_info);
+	}
+
+	free(socket_create_info);
+	socket_create_info = NULL;
+}
+
+/**
+ * @brief Frees lua_socket_create_info_array
+ * 
+ * @param event_info 
+ */
+void delete_lua_socket_create_info_array(
+	struct lua_socket_create_info_array *arr)
+{
+	if (arr == NULL) {
+		return;
+	}
+
+	if (arr->size > 0) {
+		for (int i = 0; i < arr->size; i++) {
+			delete_lua_socket_create_info(arr->values[i]);
+		}
+	}
+
+	arr->size = 0;
+	free(arr->values);
+	arr->values = NULL;
+
+	free(arr);
+	arr = NULL;
+}
+
+/**
+ * @brief handle index access of socket_create_info
+ * Expects stack to have string attribute at the top
+ * and socket_create_info user data at position -2.
+ * returns nil if error occurs.
+ * 
+ * Stack: [-2, +1]
+ * @param L
+ * @return number of return values (1)
+ */
+int socket_create_info_index(lua_State *L)
+{
+	struct lua_socket_create_info *socket_create_info;
+	const char *attribute;
+
+	ASSERT(lua_isuserdata(L, -2),
+	       "socket_create_info_index: stack[-2] not userdata");
+
+	// make sure that the attribute is string
+	if (!lua_isstring(L, -1)) {
+		fprintf(stderr,
+			"socket_create_info_index: stack[-1] not string\n");
+		lua_pop(L, 2);
+		lua_pushnil(L);
+		return 1;
+	}
+
+	// get socket_create_info light user data
+	lua_getuservalue(L, -2);
+	lua_pushstring(L, SOCKET_CREATE_INFO);
+	lua_gettable(L, -2);
+	ASSERT(lua_isuserdata(L, -1),
+	       "socket_create_info_index: socket_create_info user value not found");
+
+	socket_create_info =
+		(struct lua_socket_create_info *)lua_touserdata(L, -1);
+	ASSERT(socket_create_info != NULL,
+	       "socket_create_info_index: socket_create_info is NULL");
+
+	lua_pop(L, 2);
+
+	// get string attribute
+	attribute = lua_tostring(L, -1);
+
+	// swap attribute and socket_create_info user data
+	lua_rotate(L, -2, 1);
+	lua_pop(L, 1);
+
+	// handle attribute
+	if (IS_ATTR(attribute, EVENT_TIME)) {
+		lua_pop(L, 1);
+		lua_pushinteger(L, (lua_Integer)socket_create_info->event_info
+					   ->event_time);
+		return 1;
+	} else if (IS_ATTR(attribute, SYSCALL)) {
+		lua_pop(L, 1);
+		lua_pushinteger(
+			L,
+			(lua_Integer)socket_create_info->event_info->syscall);
+		return 1;
+	} else if (IS_ATTR(attribute, PROCESS_NAME)) {
+		lua_pop(L, 1);
+		lua_pushstring(L, socket_create_info->event_info->process_name);
+		return 1;
+	} else if (IS_ATTR(attribute, INODE_ATTR)) {
+		lua_pop(L, 1);
+		lua_pushinteger(L, (lua_Integer)socket_create_info->inode);
+		return 1;
+	} else if (IS_ATTR(attribute, FAMILY_ATTR)) {
+		lua_pop(L, 1);
+		lua_pushstring(L, socket_create_info->family);
+		return 1;
+	} else if (IS_ATTR(attribute, SOCKET_TYPE_ATTR)) {
+		lua_pop(L, 1);
+		lua_pushstring(L, socket_create_info->socket_type);
+		return 1;
+	} else {
+		fprintf(stderr,
+			"socket_create_info_index: invalid attribute: %s\n",
+			attribute);
+		lua_pop(L, 1);
+		lua_pushnil(L);
+		return 1;
+	}
+}
+
+/**
+ * @brief handle index access of socket_create_info_arr
+ * Expects stack to have integer attribute at the top
+ * and proces_context user data at position -2.
+ * returns nil if error occurs.
+ * Stack: [-2, +1]
+ * 
+ * @param L 
+ * @return Number of return values (1)
+ */
+int socket_create_info_arr_index(lua_State *L)
+{
+	struct lua_socket_create_info_array *socket_create_info_arr;
+	struct lua_socket_create_info *socket_create_info;
+	int index;
+
+	if (!lua_isinteger(L, -1)) {
+		fprintf(stderr,
+			"socket_create_info_arr_index: stack[-1] not integer\n");
+		lua_pop(L, 2);
+		lua_pushnil(L);
+		return 1;
+	}
+
+	// get the integer index
+	index = (int)lua_tointeger(L, -1);
+	ASSERT(lua_isuserdata(L, -2),
+	       "socket_create_info_arr_index: stack[-2] not userdata");
+
+	// get socket_create_info_arr_full_ud.userdata["SOCKET_CREATE_INFO_ARR"]
+	// which is the light ud
+	lua_getuservalue(L, -2);
+	ASSERT(lua_istable(L, -1),
+	       "socket_create_info_arr_index: stack[-1] not table");
+	lua_pushstring(L, SOCKET_CREATE_INFO_ARR);
+	lua_gettable(L, -2);
+
+	socket_create_info_arr =
+		(struct lua_socket_create_info_array *)lua_touserdata(L, -1);
+	ASSERT(socket_create_info_arr != NULL,
+	       "socket_create_info_arr_index: socket_create_info_arr == NULL");
+
+	lua_pop(L, 4);
+	// stack is reset
+
+	if (index <= 0 || index > socket_create_info_arr->size) {
+		lua_pushnil(L);
+	} else {
+		socket_create_info = socket_create_info_arr->values[index - 1];
+		lua_newuserdata(L, sizeof(struct lua_socket_create_info));
+
+		// stores socket_create_info (light user data) in a table as user value
+		// socket_create_info_full_ud.userdata["SOCKET_CREATE_INFO"] = socket_create_info_light_ud
+		lua_newtable(L);
+		lua_pushstring(L, SOCKET_CREATE_INFO);
+		lua_pushlightuserdata(L, socket_create_info);
+		lua_settable(L, -3);
+
+		lua_setuservalue(L, -2);
+
+		// create metatable and set some metamethods
+		luaL_newmetatable(L, SOCKET_CREATE_INFO_METATABLE);
+
+		lua_pushstring(L, "__index");
+		lua_pushcfunction(L, socket_create_info_index);
+		lua_settable(L, -3);
+
+		// sanity checks
+		ASSERT(lua_istable(L, -1), "");
+		ASSERT(lua_isuserdata(L, -2), "");
+
+		// set metatable of process context
+		lua_setmetatable(L, -2);
+
+		// make sure that we return socket_create_info user data
+		ASSERT(lua_isuserdata(L, -1),
+		       "socket_create_info_arr_index: stack[-1] not userdata");
+	}
+
+	return 1;
+}
+
+/**
+ * @brief Get the socket_create_info array length
+ * Expects the socket_create_info_array userdata on the top of the stack
+ * Stack: [-1, +1]
+ * 
+ * @param L The lua state
+ * @return Number of return values (1)
+ */
+int socket_create_info_arr_len(lua_State *L)
+{
+	struct lua_socket_create_info_array *socket_create_info_arr;
+
+	ASSERT(lua_isuserdata(L, -1),
+	       "socket_create_info_arr_len: stack[-2] not userdata");
+
+	// get socket_create_info_arr_full_ud.userdata["SOCKET_CREATE_INFO_ARR"]
+	// which is the light ud
+	lua_getuservalue(L, -1);
+	ASSERT(lua_istable(L, -1),
+	       "socket_create_info_arr_len: stack[-1] not table");
+	lua_pushstring(L, SOCKET_CREATE_INFO_ARR);
+	lua_gettable(L, -2);
+
+	socket_create_info_arr =
+		(struct lua_socket_create_info_array *)lua_touserdata(L, -1);
+	ASSERT(socket_create_info_arr != NULL,
+	       "socket_create_info_arr_len: socket_create_info_arr == NULL");
+
+	lua_pop(L, 3);
+	// stack is reset
+
+	// return the size of the socket_create_info_arr
+	lua_pushinteger(L, (lua_Integer)socket_create_info_arr->size);
+
+	return 1;
+}
+
+/**
+ * @brief Get the socket_create_info object, initialize it, populate data from db.
+ * Stack: [-1, +1]
+ * 
+ * @param L The lua state.
+ */
+void get_socket_create_info(lua_State *L)
+{
+	struct lua_process_context *process_context;
+	struct lua_socket_create_info_array *socket_create_info_arr;
+	struct lua_db *db;
+
+	process_context = (struct lua_process_context *)lua_touserdata(L, -1);
+	if (process_context == NULL) {
+		fprintf(stderr,
+			"get_socket_create_info: process_context == NULL\n");
+		lua_pop(L, 1);
+		lua_pushnil(L);
+		return;
+	}
+
+	if (process_context->socket_create_info_arr != NULL) {
+		socket_create_info_arr =
+			process_context->socket_create_info_arr;
+	} else {
+		socket_create_info_arr =
+			(struct lua_socket_create_info_array *)malloc(
+				sizeof(struct lua_socket_create_info_array));
+		socket_create_info_arr->max_size =
+			SOCKET_CREATE_INFO_CHUNK_SIZE;
+		socket_create_info_arr->size = 0;
+		socket_create_info_arr->values =
+			(struct lua_socket_create_info **)malloc(
+				sizeof(struct lua_socket_create_info *) *
+				(size_t)socket_create_info_arr->max_size);
+
+		db = get_lua_db(L);
+
+		select_all_socket_create_info(db->db, db->sqlite_stmts,
+					      socket_create_info_arr,
+					      process_context->pid);
+		process_context->socket_create_info_arr =
+			socket_create_info_arr;
+	}
+
+	lua_pop(L, 1);
+	// stack is reset
+
+	lua_newuserdata(L, sizeof(struct lua_socket_create_info_array));
+
+	// stores socket_create_info_arr (light user data) in a table as user value
+	// socket_create_info_arr_full_ud.userdata["SOCKET_CREATE_INFO_ARR"] = socket_create_info_arr_light_ud
+	lua_newtable(L);
+	lua_pushstring(L, SOCKET_CREATE_INFO_ARR);
+	lua_pushlightuserdata(L, socket_create_info_arr);
+	lua_settable(L, -3);
+	lua_setuservalue(L, -2);
+
+	// create metatable and set some metamethods
+	luaL_newmetatable(L, SOCKET_CREATE_INFO_ARR_METATABLE);
+
+	lua_pushstring(L, "__index");
+	lua_pushcfunction(L, socket_create_info_arr_index);
+	lua_settable(L, -3);
+
+	lua_pushstring(L, "__len");
+	lua_pushcfunction(L, socket_create_info_arr_len);
+	lua_settable(L, -3);
+
+	// sanity checks
+	ASSERT(lua_istable(L, -1), "");
+	ASSERT(lua_isuserdata(L, -2), "");
+
+	lua_setmetatable(L, -2);
+
+	// make sure we return the socket_create_info_arr
+	ASSERT(lua_isuserdata(L, -1), "");
+}

--- a/kalbur/rule_engine/lua/lua_socket_create_info.h
+++ b/kalbur/rule_engine/lua/lua_socket_create_info.h
@@ -1,0 +1,39 @@
+#ifndef LUA_SOCKET_CREATE_INFO_H
+#define LUA_SOCKET_CREATE_INFO_H
+
+#include <lua_process.h>
+
+#define SOCKET_CREATE_INFO_CHUNK_SIZE 100
+#define SOCKET_CREATE_INFO_ARR_METATABLE "SocketCreateInfoArrMetaTable"
+#define SOCKET_CREATE_INFO_METATABLE "SocketCreateInfoMetaTable"
+#define SOCKET_CREATE_INFO_ARR "SocketCreateInfoArr"
+#define SOCKET_CREATE_INFO "SocketCreateInfo"
+
+#define INODE_ATTR "inode"
+#define FAMILY_ATTR "family"
+#define SOCKET_TYPE_ATTR "socket_type"
+struct lua_socket_create_info {
+	struct lua_event_info *event_info;
+	u64_t inode;
+	char *family;
+	char *socket_type;
+};
+
+typedef struct lua_socket_create_info_array {
+	int max_size;
+	int size;
+	struct lua_socket_create_info **values;
+} lua_socket_create_info_array;
+
+void delete_lua_socket_create_info(
+	struct lua_socket_create_info *socket_create_info);
+void delete_lua_socket_create_info_array(
+	struct lua_socket_create_info_array *arr);
+
+int socket_create_info_index(lua_State *L);
+int socket_create_info_arr_index(lua_State *L);
+int socket_create_info_arr_len(lua_State *L);
+
+void get_socket_create_info(lua_State *L);
+
+#endif // LUA_SOCKET_CREATE_INFO_H

--- a/kalbur/rule_engine/lua/lua_tcp_connection_info.c
+++ b/kalbur/rule_engine/lua/lua_tcp_connection_info.c
@@ -1,0 +1,345 @@
+#include "lua_tcp_connection_info.h"
+
+/**
+ * @brief Frees lua_tcp_connection_info
+ * 
+ * @param event_info 
+ */
+void delete_lua_tcp_connection_info(
+	struct lua_tcp_connection_info *tcp_connection_info)
+{
+	if (tcp_connection_info == NULL) {
+		return;
+	}
+
+	if (tcp_connection_info->event_info != NULL) {
+		delete_lua_event_info(tcp_connection_info->event_info);
+	}
+
+	free(tcp_connection_info);
+	tcp_connection_info = NULL;
+}
+
+/**
+ * @brief Frees lua_tcp_connection_info_array
+ * 
+ * @param event_info 
+ */
+void delete_lua_tcp_connection_info_array(
+	struct lua_tcp_connection_info_array *arr)
+{
+	if (arr == NULL) {
+		return;
+	}
+
+	if (arr->size > 0) {
+		for (int i = 0; i < arr->size; i++) {
+			delete_lua_tcp_connection_info(arr->values[i]);
+		}
+	}
+
+	arr->size = 0;
+	free(arr->values);
+	arr->values = NULL;
+
+	free(arr);
+	arr = NULL;
+}
+
+/**
+ * @brief handle index access of tcp_connection_info
+ * Expects stack to have string attribute at the top
+ * and tcp_connection_info user data at position -2.
+ * returns nil if error occurs.
+ * 
+ * Stack: [-2, +1]
+ * @param L
+ * @return number of return values (1)
+ */
+int tcp_connection_info_index(lua_State *L)
+{
+	struct lua_tcp_connection_info *tcp_connection_info;
+	const char *attribute;
+
+	ASSERT(lua_isuserdata(L, -2),
+	       "tcp_connection_info_index: stack[-2] not userdata");
+
+	// make sure that the attribute is string
+	if (!lua_isstring(L, -1)) {
+		fprintf(stderr,
+			"tcp_connection_info_index: stack[-1] not string\n");
+		lua_pop(L, 2);
+		lua_pushnil(L);
+		return 1;
+	}
+
+	// get tcp_connection_info light user data
+	lua_getuservalue(L, -2);
+	lua_pushstring(L, TCP_CONNECTION_INFO);
+	lua_gettable(L, -2);
+	ASSERT(lua_isuserdata(L, -1),
+	       "tcp_connection_info_index: tcp_connection_info user value not found");
+
+	tcp_connection_info =
+		(struct lua_tcp_connection_info *)lua_touserdata(L, -1);
+	ASSERT(tcp_connection_info != NULL,
+	       "tcp_connection_info_index: tcp_connection_info is NULL");
+
+	lua_pop(L, 2);
+
+	// get string attribute
+	attribute = lua_tostring(L, -1);
+
+	// swap attribute and tcp_connection_info user data
+	lua_rotate(L, -2, 1);
+	lua_pop(L, 1);
+
+	// handle attribute
+	if (IS_ATTR(attribute, EVENT_TIME)) {
+		lua_pop(L, 1);
+		lua_pushinteger(L, (lua_Integer)tcp_connection_info->event_info
+					   ->event_time);
+		return 1;
+	} else if (IS_ATTR(attribute, SYSCALL)) {
+		lua_pop(L, 1);
+		lua_pushinteger(
+			L,
+			(lua_Integer)tcp_connection_info->event_info->syscall);
+		return 1;
+	} else if (IS_ATTR(attribute, PROCESS_NAME)) {
+		lua_pop(L, 1);
+		lua_pushstring(L,
+			       tcp_connection_info->event_info->process_name);
+		return 1;
+	} else if (IS_ATTR(attribute, INODE_ATTR)) {
+		lua_pop(L, 1);
+		lua_pushinteger(L, (lua_Integer)tcp_connection_info->inode);
+		return 1;
+	} else if (IS_ATTR(attribute, INET_TYPE_ATTR)) {
+		lua_pop(L, 1);
+		lua_pushstring(L, tcp_connection_info->type);
+		return 1;
+	} else if (IS_ATTR(attribute, SRC_ADDR_ATTR)) {
+		lua_pop(L, 1);
+		lua_pushstring(L, tcp_connection_info->src_addr);
+		return 1;
+	} else if (IS_ATTR(attribute, DST_ADDR_ATTR)) {
+		lua_pop(L, 1);
+		lua_pushstring(L, tcp_connection_info->dst_addr);
+		return 1;
+	} else if (IS_ATTR(attribute, SRC_PORT_ATTR)) {
+		lua_pop(L, 1);
+		lua_pushinteger(L, (lua_Integer)tcp_connection_info->src_port);
+		return 1;
+	} else if (IS_ATTR(attribute, DST_PORT_ATTR)) {
+		lua_pop(L, 1);
+		lua_pushinteger(L, (lua_Integer)tcp_connection_info->dst_port);
+		return 1;
+	} else {
+		fprintf(stderr,
+			"tcp_connection_info_index: invalid attribute: %s\n",
+			attribute);
+		lua_pop(L, 1);
+		lua_pushnil(L);
+		return 1;
+	}
+}
+
+/**
+ * @brief handle index access of tcp_connection_info_arr
+ * Expects stack to have integer attribute at the top
+ * and proces_context user data at position -2.
+ * returns nil if error occurs.
+ * Stack: [-2, +1]
+ * 
+ * @param L 
+ * @return Number of return values (1)
+ */
+int tcp_connection_info_arr_index(lua_State *L)
+{
+	struct lua_tcp_connection_info_array *tcp_connection_info_arr;
+	struct lua_tcp_connection_info *tcp_connection_info;
+	int index;
+
+	if (!lua_isinteger(L, -1)) {
+		fprintf(stderr,
+			"tcp_connection_info_arr_index: stack[-1] not integer\n");
+		lua_pop(L, 2);
+		lua_pushnil(L);
+		return 1;
+	}
+
+	// get the integer index
+	index = (int)lua_tointeger(L, -1);
+	ASSERT(lua_isuserdata(L, -2),
+	       "tcp_connection_info_arr_index: stack[-2] not userdata");
+
+	// get tcp_connection_info_arr_full_ud.userdata["TCP_CONNECTION_INFO_ARR"]
+	// which is the light ud
+	lua_getuservalue(L, -2);
+	ASSERT(lua_istable(L, -1),
+	       "tcp_connection_info_arr_index: stack[-1] not table");
+	lua_pushstring(L, TCP_CONNECTION_INFO_ARR);
+	lua_gettable(L, -2);
+
+	tcp_connection_info_arr =
+		(struct lua_tcp_connection_info_array *)lua_touserdata(L, -1);
+	ASSERT(tcp_connection_info_arr != NULL,
+	       "tcp_connection_info_arr_index: tcp_connection_info_arr == NULL");
+
+	lua_pop(L, 4);
+	// stack is reset
+
+	if (index <= 0 || index > tcp_connection_info_arr->size) {
+		lua_pushnil(L);
+	} else {
+		tcp_connection_info =
+			tcp_connection_info_arr->values[index - 1];
+		lua_newuserdata(L, sizeof(struct lua_tcp_connection_info));
+
+		// stores tcp_connection_info (light user data) in a table as user value
+		// tcp_connection_info_full_ud.userdata["TCP_CONNECTION_INFO"] = tcp_connection_info_light_ud
+		lua_newtable(L);
+		lua_pushstring(L, TCP_CONNECTION_INFO);
+		lua_pushlightuserdata(L, tcp_connection_info);
+		lua_settable(L, -3);
+
+		lua_setuservalue(L, -2);
+
+		// create metatable and set some metamethods
+		luaL_newmetatable(L, TCP_CONNECTION_INFO_METATABLE);
+
+		lua_pushstring(L, "__index");
+		lua_pushcfunction(L, tcp_connection_info_index);
+		lua_settable(L, -3);
+
+		// sanity checks
+		ASSERT(lua_istable(L, -1), "");
+		ASSERT(lua_isuserdata(L, -2), "");
+
+		// set metatable of process context
+		lua_setmetatable(L, -2);
+
+		// make sure that we return tcp_connection_info user data
+		ASSERT(lua_isuserdata(L, -1),
+		       "tcp_connection_info_arr_index: stack[-1] not userdata");
+	}
+
+	return 1;
+}
+
+/**
+ * @brief Get the tcp_connection_info array length
+ * Expects the tcp_connection_info_array userdata on the top of the stack
+ * Stack: [-1, +1]
+ * 
+ * @param L The lua state
+ * @return Number of return values (1)
+ */
+int tcp_connection_info_arr_len(lua_State *L)
+{
+	struct lua_tcp_connection_info_array *tcp_connection_info_arr;
+
+	ASSERT(lua_isuserdata(L, -1),
+	       "tcp_connection_info_arr_len: stack[-2] not userdata");
+
+	// get tcp_connection_info_arr_full_ud.userdata["TCP_CONNECTION_INFO_ARR"]
+	// which is the light ud
+	lua_getuservalue(L, -1);
+	ASSERT(lua_istable(L, -1),
+	       "tcp_connection_info_arr_len: stack[-1] not table");
+	lua_pushstring(L, TCP_CONNECTION_INFO_ARR);
+	lua_gettable(L, -2);
+
+	tcp_connection_info_arr =
+		(struct lua_tcp_connection_info_array *)lua_touserdata(L, -1);
+	ASSERT(tcp_connection_info_arr != NULL,
+	       "tcp_connection_info_arr_len: tcp_connection_info_arr == NULL");
+
+	lua_pop(L, 3);
+	// stack is reset
+
+	// return the size of the tcp_connection_info_arr
+	lua_pushinteger(L, (lua_Integer)tcp_connection_info_arr->size);
+
+	return 1;
+}
+
+/**
+ * @brief Get the tcp_connection_info object, initialize it, populate data from db.
+ * Stack: [-1, +1]
+ * 
+ * @param L The lua state.
+ */
+void get_tcp_connection_info(lua_State *L)
+{
+	struct lua_process_context *process_context;
+	struct lua_tcp_connection_info_array *tcp_connection_info_arr;
+	struct lua_db *db;
+
+	process_context = (struct lua_process_context *)lua_touserdata(L, -1);
+	if (process_context == NULL) {
+		fprintf(stderr,
+			"get_tcp_connection_info: process_context == NULL\n");
+		lua_pop(L, 1);
+		lua_pushnil(L);
+		return;
+	}
+
+	if (process_context->tcp_connection_info_arr != NULL) {
+		tcp_connection_info_arr =
+			process_context->tcp_connection_info_arr;
+	} else {
+		tcp_connection_info_arr =
+			(struct lua_tcp_connection_info_array *)malloc(
+				sizeof(struct lua_tcp_connection_info_array));
+		tcp_connection_info_arr->max_size =
+			TCP_CONNECTION_INFO_CHUNK_SIZE;
+		tcp_connection_info_arr->size = 0;
+		tcp_connection_info_arr->values =
+			(struct lua_tcp_connection_info **)malloc(
+				sizeof(struct lua_tcp_connection_info *) *
+				(size_t)tcp_connection_info_arr->max_size);
+
+		db = get_lua_db(L);
+
+		select_all_tcp_connection_info(db->db, db->sqlite_stmts,
+					       tcp_connection_info_arr,
+					       process_context->pid);
+		process_context->tcp_connection_info_arr =
+			tcp_connection_info_arr;
+	}
+
+	lua_pop(L, 1);
+	// stack is reset
+
+	lua_newuserdata(L, sizeof(struct lua_tcp_connection_info_array));
+
+	// stores tcp_connection_info_arr (light user data) in a table as user value
+	// tcp_connection_info_arr_full_ud.userdata["TCP_CONNECTION_INFO_ARR"] = tcp_connection_info_arr_light_ud
+	lua_newtable(L);
+	lua_pushstring(L, TCP_CONNECTION_INFO_ARR);
+	lua_pushlightuserdata(L, tcp_connection_info_arr);
+	lua_settable(L, -3);
+	lua_setuservalue(L, -2);
+
+	// create metatable and set some metamethods
+	luaL_newmetatable(L, TCP_CONNECTION_INFO_ARR_METATABLE);
+
+	lua_pushstring(L, "__index");
+	lua_pushcfunction(L, tcp_connection_info_arr_index);
+	lua_settable(L, -3);
+
+	lua_pushstring(L, "__len");
+	lua_pushcfunction(L, tcp_connection_info_arr_len);
+	lua_settable(L, -3);
+
+	// sanity checks
+	ASSERT(lua_istable(L, -1), "");
+	ASSERT(lua_isuserdata(L, -2), "");
+
+	lua_setmetatable(L, -2);
+
+	// make sure we return the tcp_connection_info_arr
+	ASSERT(lua_isuserdata(L, -1), "");
+}

--- a/kalbur/rule_engine/lua/lua_tcp_connection_info.c
+++ b/kalbur/rule_engine/lua/lua_tcp_connection_info.c
@@ -16,6 +16,21 @@ void delete_lua_tcp_connection_info(
 		delete_lua_event_info(tcp_connection_info->event_info);
 	}
 
+    if (tcp_connection_info->type != NULL) {
+        free(tcp_connection_info->type);
+        tcp_connection_info->type = NULL;
+    }
+
+    if (tcp_connection_info->src_addr != NULL) {
+        free(tcp_connection_info->src_addr);
+        tcp_connection_info->src_addr = NULL;
+    }
+
+    if (tcp_connection_info->dst_addr != NULL) {
+        free(tcp_connection_info->dst_addr);
+        tcp_connection_info->dst_addr = NULL;
+    }
+
 	free(tcp_connection_info);
 	tcp_connection_info = NULL;
 }

--- a/kalbur/rule_engine/lua/lua_tcp_connection_info.h
+++ b/kalbur/rule_engine/lua/lua_tcp_connection_info.h
@@ -1,0 +1,45 @@
+#ifndef LUA_TCP_CONNECTION_INFO_H
+#define LUA_TCP_CONNECTION_INFO_H
+
+#include <lua_process.h>
+
+#define TCP_CONNECTION_INFO_CHUNK_SIZE 100
+#define TCP_CONNECTION_INFO_ARR_METATABLE "TcpConnectionInfoArrMetaTable"
+#define TCP_CONNECTION_INFO_METATABLE "TcpConnectionInfoMetaTable"
+#define TCP_CONNECTION_INFO_ARR "TcpConnectionInfoArr"
+#define TCP_CONNECTION_INFO "TcpConnectionInfo"
+
+#define INODE_ATTR "inode"
+#define INET_TYPE_ATTR "inet_type"
+#define SRC_ADDR_ATTR "src_addr"
+#define DST_ADDR_ATTR "dst_addr"
+#define SRC_PORT_ATTR "src_port"
+#define DST_PORT_ATTR "dst_port"
+struct lua_tcp_connection_info {
+	struct lua_event_info *event_info;
+	char *type;
+	char *src_addr;
+	char *dst_addr;
+	int src_port;
+	int dst_port;
+	int inode;
+};
+
+typedef struct lua_tcp_connection_info_array {
+	int max_size;
+	int size;
+	struct lua_tcp_connection_info **values;
+} lua_tcp_connection_info_array;
+
+void delete_lua_tcp_connection_info(
+	struct lua_tcp_connection_info *tcp_connection_info);
+void delete_lua_tcp_connection_info_array(
+	struct lua_tcp_connection_info_array *arr);
+
+int tcp_connection_info_index(lua_State *L);
+int tcp_connection_info_arr_index(lua_State *L);
+int tcp_connection_info_arr_len(lua_State *L);
+
+void get_tcp_connection_info(lua_State *L);
+
+#endif // LUA_TCP_CONNECTION_INFO_H

--- a/kalbur/rule_engine/save_ms.c
+++ b/kalbur/rule_engine/save_ms.c
@@ -467,7 +467,6 @@ MESSAGE_HANDLER_FUNC(save_exit_event)
 	if (err != CODE_SUCCESS)
 		return err;
 
-	printf("exit event syscall nr: %d\n", ((struct probe_event_header *)ms->primary_data)->syscall_nr);
 	event_id = insert_event(db, ht,
 				(struct probe_event_header *)ms->primary_data);
 	if (ERR_NOT_SUCCESS(event_id)) {

--- a/tests/unit/check_database.c
+++ b/tests/unit/check_database.c
@@ -225,7 +225,8 @@ int validate_callback__insert_event(void *eh_in, int n, char **vals,
 					l, eh->event_time);
 				return 1;
 			}
-		} else if (strcmp(names[i], TGID_PID) == 0) {
+		} else if (strcmp(names[i], TGID) == 0) {
+			// TODO: fix this test for TGID & PID
 			l = strtol(vals[i], NULL, 10);
 			if (l == 0) {
 				fprintf(stderr,
@@ -570,6 +571,7 @@ int validate_callback__insert_proc_info(void *msg_in, int n, char **vals,
 	char *args = NULL;
 
 	for (int i = 0; i < n; i++) {
+		// TODO: Fix the test as ppid is split in two columns
 		if (strcmp(names[i], PPID) == 0) {
 			l = strtol(vals[i], NULL, 10);
 			if (l == 0) {

--- a/third_party/lua/.gitignore
+++ b/third_party/lua/.gitignore
@@ -1,0 +1,2 @@
+lua
+luac


### PR DESCRIPTION
- Add a method `get_process_by_pid` in Lua to get the process context by the PID and expose the following information about the process context from the DB:
  - MmapInfo
  - ProcessInfo
  - PtraceInfo
  - SocketCreateInfo
  - TcpConnectionInfo
  - ModuleLoadInfo
  - ModprobeOverwriteInfo
  - ProcessLPEInfo
  
A sample Lua script is attached to show the usage of the exposed functionality.
[process_context.zip](https://github.com/trapmine/trapmine-linux-sensor/files/8798716/process_context.zip)