### PR TITLE
Clone flags

### DIFF
--- a/kalbur/missing_defs.h
+++ b/kalbur/missing_defs.h
@@ -73,4 +73,10 @@
 /* include/linux/mm.h */
 #define VM_EXEC 0x00000004
 
+/* arch/x86/include/asm/page_64_types.h */
+#define THREAD_SIZE_ORDER 2
+#define THREAD_SIZE (PAGE_SIZE << THREAD_SIZE_ORDER)
+
+#define TOP_OF_KERNEL_STACK_PADDING 0
+
 #endif // MISSING_DEFS

--- a/kalbur/proc_monitor.bpf.c
+++ b/kalbur/proc_monitor.bpf.c
@@ -147,10 +147,9 @@ struct syscall_exit_fork_clone_ctx {
 		// the actual pid seen by host system??)
 };
 
-struct syscall_enter_clone3_args {
+struct syscall_enter_fork_clone_ctx {
 	u64 unused;
 	int syscall_nr;
-	struct clone_args *uargs;
 };
 
 struct syscall_enter_mprotect {

--- a/kalbur/proc_monitor.bpf.c
+++ b/kalbur/proc_monitor.bpf.c
@@ -2315,7 +2315,7 @@ int kprobe__security_bprm_check(struct pt_regs *ctx)
 	if (new_pinfo.file.s_magic == TMPFS_MAGIC)
 		new_pinfo.dump = 1;
 
-	err = bpf_core_read(&credentials, sizeof(struct creds), &lbprm->cred);
+	err = bpf_core_read(&credentials, sizeof(struct cred *), &lbprm->cred);
 	JUMP_TARGET(out);
 	err = save_credentials(credentials, &new_pinfo);
 

--- a/kalbur/proc_monitor.bpf.c
+++ b/kalbur/proc_monitor.bpf.c
@@ -128,7 +128,6 @@ struct syscall_execve_ctx {
 	long envp_str_arr_ptr;
 };
 
-
 struct syscall_enter_mmap_ctx {
 	u64 unused;
 	int syscall_nr;
@@ -405,11 +404,11 @@ set_buff_indx(u32 buff_num, u32 str_value, u32 mmap_value, u32 lock)
 		return -EBPFLOOKUPFAIL;
 
 	new_tracker.curr_str_indx = str_value == PRESERVE_STR_INDX ?
-						  tracker->curr_str_indx :
-						  str_value;
+					    tracker->curr_str_indx :
+					    str_value;
 	new_tracker.curr_mmap_indx = mmap_value == PRESERVE_MMAP_INDX ?
-						   tracker->curr_mmap_indx :
-						   mmap_value;
+					     tracker->curr_mmap_indx :
+					     mmap_value;
 	new_tracker.locked = lock;
 
 	return bpf_map_update_elem(&buff_tracker_map, &buff_num, &new_tracker,

--- a/kalbur/proc_monitor.bpf.c
+++ b/kalbur/proc_monitor.bpf.c
@@ -2528,8 +2528,6 @@ get_registers(struct task_struct *task, struct pt_regs **regs)
 SEC("tracepoint/syscalls/sys_exit_vfork")
 int tracepoint__syscalls__sys_exit_vfork(struct syscall_exit_fork_clone_ctx *ctx)
 {
-	CHECK_SYSCALL_RET(ctx->pid);
-handle_exit:
 	handle_fork_clone_exit(ctx);
 	return 0;
 }
@@ -2537,8 +2535,14 @@ handle_exit:
 SEC("tracepoint/syscalls/sys_exit_clone")
 int tracepoint__syscalls__sys_exit_clone(struct syscall_exit_fork_clone_ctx *ctx)
 {
-	CHECK_SYSCALL_RET(ctx->pid);
-handle_exit:
+	handle_fork_clone_exit(ctx);
+	return 0;
+}
+
+SEC("tracepoint/syscalls/sys_exit_clone3")
+int tracepoint__syscalls__sys_exit_clone3(
+	struct syscall_exit_fork_clone_ctx *ctx)
+{
 	handle_fork_clone_exit(ctx);
 	return 0;
 }
@@ -2546,9 +2550,39 @@ handle_exit:
 SEC("tracepoint/syscalls/sys_exit_fork")
 int tracepoint__syscalls__sys_exit_fork(struct syscall_exit_fork_clone_ctx *ctx)
 {
-	CHECK_SYSCALL_RET(ctx->pid);
-handle_exit:
 	handle_fork_clone_exit(ctx);
+	return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_vfork")
+int tracepoint__syscalls__sys_enter_vfork(
+	struct syscall_enter_fork_clone_ctx *ctx)
+{
+	handle_fork_clone_enter(ctx->syscall_nr);
+	return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_clone")
+int tracepoint__syscalls__sys_enter_clone(
+	struct syscall_enter_fork_clone_ctx *ctx)
+{
+	handle_fork_clone_enter(ctx->syscall_nr);
+	return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_clone3")
+int tracepoint__syscalls__sys_enter_clone3(
+	struct syscall_enter_fork_clone_ctx *ctx)
+{
+	handle_fork_clone_enter(ctx->syscall_nr);
+	return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_fork")
+int tracepoint__syscalls__sys_enter_fork(
+	struct syscall_enter_fork_clone_ctx *ctx)
+{
+	handle_fork_clone_enter(ctx->syscall_nr);
 	return 0;
 }
 

--- a/kalbur/proc_monitor.bpf.c
+++ b/kalbur/proc_monitor.bpf.c
@@ -2508,6 +2508,23 @@ out:
 	return 0;
 }
 
+// get userspace registers for a task
+__attribute__((always_inline)) static long
+get_registers(struct task_struct *task, struct pt_regs **regs)
+{
+	u64 __ptr;
+	long err;
+
+	err = bpf_core_read(&__ptr, sizeof(__ptr), &(task->stack));
+	if (err < 0)
+		return err;
+
+	__ptr += THREAD_SIZE - TOP_OF_KERNEL_STACK_PADDING;
+	*regs = ((struct pt_regs *)__ptr) - 1;
+
+	return 0;
+}
+
 SEC("tracepoint/syscalls/sys_exit_vfork")
 int tracepoint__syscalls__sys_exit_vfork(struct syscall_exit_fork_clone_ctx *ctx)
 {

--- a/kalbur/proc_monitor.bpf.c
+++ b/kalbur/proc_monitor.bpf.c
@@ -128,16 +128,7 @@ struct syscall_execve_ctx {
 	long envp_str_arr_ptr;
 };
 
-struct syscall_enter_fork_ctx {
-	u64 unused;
-	int syscall_nr;
-};
 
-struct syscall_enter_clone_ctx {
-	u64 unused;
-	int syscall_nr;
-	unsigned long clone_flags;
-};
 struct syscall_enter_mmap_ctx {
 	u64 unused;
 	int syscall_nr;

--- a/kalbur/rule_engine/save_ms.c
+++ b/kalbur/rule_engine/save_ms.c
@@ -518,6 +518,8 @@ int save_msg(sqlite3 *db, hashtable_t *hash_table, struct message_state *ms)
 		return save_fork_and_friends_event(db, hash_table, ms);
 	case (SYS_CLONE):
 		return save_fork_and_friends_event(db, hash_table, ms);
+	case (SYS_CLONE3):
+		return save_fork_and_friends_event(db, hash_table, ms);
 	case (SYS_PTRACE):
 		return save_ptrace_event(db, hash_table, ms);
 	case (SYS_FINIT_MODULE):

--- a/kalbur/syscall_defs.h
+++ b/kalbur/syscall_defs.h
@@ -17,6 +17,7 @@
 #define SYS_FORK __NR_fork
 #define SYS_VFORK __NR_vfork
 #define SYS_CLONE __NR_clone
+#define SYS_CLONE3 __NR_clone3
 #define SYS_MPROTECT __NR_mprotect
 #ifdef SYS_SOCKET
 #undef SYS_SOCKET
@@ -51,7 +52,7 @@
 
 #define IS_FORK_OR_FRIENDS(syscall)                                            \
 	((syscall == SYS_FORK) || (syscall == SYS_VFORK) ||                    \
-	 (syscall == SYS_CLONE))
+	 (syscall == SYS_CLONE) || (syscall == SYS_CLONE3))
 
 #define IS_EVENT_HANDLED(syscall)                                              \
 	((IS_SYSCALL_HANDLED(syscall)) || (syscall == DUMP_MMAP_DATA) ||       \


### PR DESCRIPTION
- Support extracting clone_flags from fork family syscalls.
- Fix semantics of process-launch event due to fork family syscalls. Such an event now has tgid, pid of the child and parent_tgid, parent_pid of the real parent of the child process.
- Add clone3 syscall in the supported fork family.